### PR TITLE
Remove database prefixes from ClickHouse table creation scripts

### DIFF
--- a/internal/tools/clickhouse_create_block_failures_table.sql
+++ b/internal/tools/clickhouse_create_block_failures_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE orchestrator.block_failures (
+CREATE TABLE block_failures (
     `chain_id` UInt256,
     `block_number` UInt256,
     `last_error_timestamp` UInt64 CODEC(Delta, ZSTD),

--- a/internal/tools/clickhouse_create_blocks_table.sql
+++ b/internal/tools/clickhouse_create_blocks_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE base.blocks (
+CREATE TABLE blocks (
     `chain_id` UInt256,
     `number` UInt256,
     `timestamp` UInt64 CODEC(Delta, ZSTD),

--- a/internal/tools/clickhouse_create_logs_table.sql
+++ b/internal/tools/clickhouse_create_logs_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE base.logs (
+CREATE TABLE logs (
     `chain_id` UInt256,
     `block_number` UInt256,
     `block_hash` FixedString(66),
@@ -19,6 +19,6 @@ CREATE TABLE base.logs (
     INDEX idx_block_hash block_hash TYPE bloom_filter GRANULARITY 1,
     INDEX idx_address address TYPE bloom_filter GRANULARITY 1,
     INDEX idx_topic0 topic_0 TYPE bloom_filter GRANULARITY 1,
-) ENGINE = SharedReplacingMergeTree(insert_timestamp, is_deleted)
+) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
 ORDER BY (chain_id, transaction_hash, log_index, block_hash)
 SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;

--- a/internal/tools/clickhouse_create_staging_table.sql
+++ b/internal/tools/clickhouse_create_staging_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE staging.block_data (
+CREATE TABLE block_data (
     `chain_id` UInt256,
     `block_number` UInt256,
     `data` String,

--- a/internal/tools/clickhouse_create_traces_table.sql
+++ b/internal/tools/clickhouse_create_traces_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE base.traces (
+CREATE TABLE traces (
     `chain_id` UInt256,
     `block_number` UInt256,
     `block_hash` FixedString(66),

--- a/internal/tools/clickhouse_create_transactions_table.sql
+++ b/internal/tools/clickhouse_create_transactions_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE base.transactions (
+CREATE TABLE transactions (
     `chain_id` UInt256,
     `hash` FixedString(66),
     `nonce` UInt64,


### PR DESCRIPTION
### TL;DR

Removed database prefixes from table names in ClickHouse SQL scripts and updated engine type for logs table.

### What changed?

- Removed database prefixes (`orchestrator.`, `base.`, and `staging.`) from all table names in ClickHouse SQL creation scripts.
- Changed the engine for the `logs` table from `SharedReplacingMergeTree` to `ReplacingMergeTree`. Shared is only available in hosted version and will be applied automatically if you create a ReplacingMergeTree

### How to test?

1. Execute the updated SQL scripts in a ClickHouse environment.
2. Verify that tables are created without database prefixes.
3. Confirm that the `logs` table is created with the `ReplacingMergeTree` engine.
4. Ensure that all other table structures and settings remain unchanged.

### Why make this change?

- Removing database prefixes allows for more flexibility in table placement and database organization. We don't want to enforce if these tables are used in one database or several
