### PR TITLE
Add poller last triggered block metric and improve block number handling

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -50,6 +50,13 @@ var (
 	})
 )
 
+var (
+	PollerLastTriggeredBlock = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "poller_last_triggered_block",
+		Help: "The last block number that the poller was triggered for",
+	})
+)
+
 // Failure Recoverer Metrics
 var (
 	FailureRecovererLastTriggeredBlock = promauto.NewGauge(prometheus.GaugeOpts{

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -95,6 +95,9 @@ func (p *Poller) Start() {
 				}
 				log.Debug().Msgf("Polling %d blocks starting from %s to %s", len(blockNumbers), blockNumbers[0], endBlock)
 
+				endBlockNumberFloat, _ := endBlock.Float64()
+				metrics.PollerLastTriggeredBlock.Set(endBlockNumberFloat)
+
 				worker := worker.NewWorker(p.rpc)
 				results := worker.Run(blockNumbers)
 				p.handleWorkerResults(results)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -92,9 +92,8 @@ func (w *Worker) Run(blockNumbers []*big.Int) []WorkerResult {
 
 	// track the last fetched block number
 	if len(results) > 0 {
-		// dividing by 10 to avoid scientific notation (e.g. 1.23456e+07)
-		// TODO: find a solution
-		metrics.LastFetchedBlock.Set(float64(results[len(results)-1].BlockNumber.Uint64()) / 10)
+		lastBlockNumberFloat, _ := results[len(results)-1].BlockNumber.Float64()
+		metrics.LastFetchedBlock.Set(lastBlockNumberFloat)
 	}
 	return results
 }


### PR DESCRIPTION
### TL;DR

Added a new metric for the last triggered block in the poller and improved block number tracking.
Removed the division by 10, because this should be configured in Grafana settings to not display scientific notation

### What changed?

- Introduced a new Prometheus gauge metric `poller_last_triggered_block` to track the last block number that triggered the poller.
- Updated the `Poller.Start()` method to set the new metric with the end block number of each polling cycle.
- Modified the `Worker.Run()` method to use `Float64()` instead of dividing by 10 when setting the `LastFetchedBlock` metric, addressing a TODO and improving precision.

### How to test?

1. Run the application and ensure it starts without errors.
2. Check Prometheus metrics to verify the new `poller_last_triggered_block` metric is present and updating correctly.
3. Confirm that the `LastFetchedBlock` metric is now reporting accurate values without scientific notation.

### Why make this change?

- The new `poller_last_triggered_block` metric provides better visibility into the poller's progress, allowing for more accurate monitoring and debugging.
- Updating the `LastFetchedBlock` metric calculation improves precision and removes the need for the temporary division workaround, enhancing the overall reliability of the metrics system.