### PR TITLE
Add Swagger JSON endpoint

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -42,6 +42,10 @@ func RunApi(cmd *cobra.Command, args []string) {
 
 	// Add Swagger route
 	r.GET("/swagger/*any", ginSwagger.WrapHandler(swaggerFiles.Handler))
+	// Add Swagger JSON endpoint
+	r.GET("/json", func(c *gin.Context) {
+		c.File("./docs/swagger.json")
+	})
 
 	root := r.Group("/:chainId")
 	{


### PR DESCRIPTION
### TL;DR

Added a new endpoint to serve Swagger JSON file.

### What changed?

- Introduced a new GET route `/json` in the API.
- This route serves the `swagger.json` file located in the `./docs` directory.

### How to test?

1. Start the API server.
2. Make a GET request to `http://your-api-host/json`.
3. Verify that the response is the contents of the `swagger.json` file.

### Why make this change?

This change allows direct access to the Swagger JSON file, which can be useful for:
- Integrating with external tools that consume Swagger/OpenAPI specifications.
- Enabling developers to easily download and use the API documentation offline.
- Facilitating automated testing or documentation generation processes that require the raw Swagger JSON.