### PR TITLE
Refactor data insertion logic 

### DIFF
--- a/internal/orchestrator/committer.go
+++ b/internal/orchestrator/committer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -57,7 +56,7 @@ func (c *Committer) Start() {
 				log.Error().Err(err).Msg("Error getting block data to commit")
 				continue
 			}
-			if len(blockDataToCommit) == 0 {
+			if blockDataToCommit == nil || len(*blockDataToCommit) == 0 {
 				log.Debug().Msg("No block data to commit")
 				continue
 			}
@@ -95,7 +94,7 @@ func (c *Committer) getBlockNumbersToCommit() ([]*big.Int, error) {
 	return blockNumbers, nil
 }
 
-func (c *Committer) getSequentialBlockDataToCommit() ([]common.BlockData, error) {
+func (c *Committer) getSequentialBlockDataToCommit() (*[]common.BlockData, error) {
 	blocksToCommit, err := c.getBlockNumbersToCommit()
 	if err != nil {
 		return nil, fmt.Errorf("error determining blocks to commit: %v", err)
@@ -104,129 +103,65 @@ func (c *Committer) getSequentialBlockDataToCommit() ([]common.BlockData, error)
 		return nil, nil
 	}
 
-	blocksData, err := c.storage.StagingStorage.GetBlockData(storage.QueryFilter{BlockNumbers: blocksToCommit, ChainId: c.rpc.ChainID})
+	blocksData, err := c.storage.StagingStorage.GetStagingData(storage.QueryFilter{BlockNumbers: blocksToCommit, ChainId: c.rpc.ChainID})
 	if err != nil {
 		return nil, fmt.Errorf("error fetching blocks to commit: %v", err)
 	}
-	if len(blocksData) == 0 {
+	if blocksData == nil || len(*blocksData) == 0 {
 		log.Warn().Msgf("Committer didn't find the following range in staging: %v - %v", blocksToCommit[0].Int64(), blocksToCommit[len(blocksToCommit)-1].Int64())
 		return nil, nil
 	}
 
 	// Sort blocks by block number
-	sort.Slice(blocksData, func(i, j int) bool {
-		return blocksData[i].Block.Number.Cmp(blocksData[j].Block.Number) < 0
+	sort.Slice(*blocksData, func(i, j int) bool {
+		return (*blocksData)[i].Block.Number.Cmp((*blocksData)[j].Block.Number) < 0
 	})
 
-	if blocksData[0].Block.Number.Cmp(blocksToCommit[0]) != 0 {
-		return nil, c.handleGap(blocksToCommit[0], blocksData[0].Block)
+	if (*blocksData)[0].Block.Number.Cmp(blocksToCommit[0]) != 0 {
+		return nil, c.handleGap(blocksToCommit[0], (*blocksData)[0].Block)
 	}
 
 	var sequentialBlockData []common.BlockData
-	sequentialBlockData = append(sequentialBlockData, blocksData[0])
-	expectedBlockNumber := new(big.Int).Add(blocksData[0].Block.Number, big.NewInt(1))
+	sequentialBlockData = append(sequentialBlockData, (*blocksData)[0])
+	expectedBlockNumber := new(big.Int).Add((*blocksData)[0].Block.Number, big.NewInt(1))
 
-	for i := 1; i < len(blocksData); i++ {
-		if blocksData[i].Block.Number.Cmp(expectedBlockNumber) != 0 {
+	for i := 1; i < len(*blocksData); i++ {
+		if (*blocksData)[i].Block.Number.Cmp(expectedBlockNumber) != 0 {
 			// Note: Gap detected, stop here
-			log.Warn().Msgf("Gap detected at block %s, committing until %s", expectedBlockNumber.String(), blocksData[i-1].Block.Number.String())
+			log.Warn().Msgf("Gap detected at block %s, committing until %s", expectedBlockNumber.String(), (*blocksData)[i-1].Block.Number.String())
 			// increment the a gap counter in prometheus
 			metrics.GapCounter.Inc()
 			// record the first missed block number in prometheus
-			metrics.MissedBlockNumbers.Set(float64(blocksData[0].Block.Number.Int64()))
+			metrics.MissedBlockNumbers.Set(float64((*blocksData)[0].Block.Number.Int64()))
 			break
 		}
-		sequentialBlockData = append(sequentialBlockData, blocksData[i])
+		sequentialBlockData = append(sequentialBlockData, (*blocksData)[i])
 		expectedBlockNumber.Add(expectedBlockNumber, big.NewInt(1))
 	}
 
-	return sequentialBlockData, nil
+	return &sequentialBlockData, nil
 }
 
-func (c *Committer) commit(blockData []common.BlockData) error {
-	blockNumbers := make([]*big.Int, len(blockData))
-	for i, block := range blockData {
+func (c *Committer) commit(blockData *[]common.BlockData) error {
+	blockNumbers := make([]*big.Int, len(*blockData))
+	for i, block := range *blockData {
 		blockNumbers[i] = block.Block.Number
 	}
 	log.Debug().Msgf("Committing %d blocks", len(blockNumbers))
 
 	// TODO if next parts (saving or deleting) fail, we'll have to do a rollback
-	if err := c.saveDataToMainStorage(blockData); err != nil {
+	if err := c.storage.MainStorage.InsertBlockData(blockData); err != nil {
 		log.Error().Err(err).Msgf("Failed to commit blocks: %v", blockNumbers)
 		return fmt.Errorf("error saving data to main storage: %v", err)
 	}
 
-	if err := c.storage.StagingStorage.DeleteBlockData(blockData); err != nil {
+	if err := c.storage.StagingStorage.DeleteStagingData(blockData); err != nil {
 		return fmt.Errorf("error deleting data from staging storage: %v", err)
 	}
 
 	// Update metrics for successful commits
-	metrics.SuccessfulCommits.Add(float64(len(blockData)))
-	metrics.LastCommittedBlock.Set(float64(blockData[len(blockData)-1].Block.Number.Int64()))
-
-	return nil
-}
-
-func (c *Committer) saveDataToMainStorage(blockData []common.BlockData) error {
-	var commitWg sync.WaitGroup
-	commitWg.Add(4)
-
-	var commitErr error
-	var commitErrMutex sync.Mutex
-
-	blocks := make([]common.Block, 0, len(blockData))
-	logs := make([]common.Log, 0)
-	transactions := make([]common.Transaction, 0)
-	traces := make([]common.Trace, 0)
-
-	for _, block := range blockData {
-		blocks = append(blocks, block.Block)
-		logs = append(logs, block.Logs...)
-		transactions = append(transactions, block.Transactions...)
-		traces = append(traces, block.Traces...)
-	}
-
-	go func() {
-		defer commitWg.Done()
-		if err := c.storage.MainStorage.InsertBlocks(blocks); err != nil {
-			commitErrMutex.Lock()
-			commitErr = fmt.Errorf("error inserting blocks: %v", err)
-			commitErrMutex.Unlock()
-		}
-	}()
-
-	go func() {
-		defer commitWg.Done()
-		if err := c.storage.MainStorage.InsertLogs(logs); err != nil {
-			commitErrMutex.Lock()
-			commitErr = fmt.Errorf("error inserting logs: %v", err)
-			commitErrMutex.Unlock()
-		}
-	}()
-
-	go func() {
-		defer commitWg.Done()
-		if err := c.storage.MainStorage.InsertTransactions(transactions); err != nil {
-			commitErrMutex.Lock()
-			commitErr = fmt.Errorf("error inserting transactions: %v", err)
-			commitErrMutex.Unlock()
-		}
-	}()
-
-	go func() {
-		defer commitWg.Done()
-		if err := c.storage.MainStorage.InsertTraces(traces); err != nil {
-			commitErrMutex.Lock()
-			commitErr = fmt.Errorf("error inserting traces: %v", err)
-			commitErrMutex.Unlock()
-		}
-	}()
-
-	commitWg.Wait()
-
-	if commitErr != nil {
-		return commitErr
-	}
+	metrics.SuccessfulCommits.Add(float64(len(*blockData)))
+	metrics.LastCommittedBlock.Set(float64((*blockData)[len(*blockData)-1].Block.Number.Int64()))
 
 	return nil
 }

--- a/internal/orchestrator/failure_recoverer.go
+++ b/internal/orchestrator/failure_recoverer.go
@@ -114,7 +114,7 @@ func (fr *FailureRecoverer) handleWorkerResults(blockFailures []common.BlockFail
 			failuresToDelete = append(failuresToDelete, blockFailureForBlock)
 		}
 	}
-	if err := fr.storage.StagingStorage.InsertBlockData(successfulResults); err != nil {
+	if err := fr.storage.StagingStorage.InsertStagingData(successfulResults); err != nil {
 		log.Error().Err(fmt.Errorf("error inserting block data in failure recoverer: %v", err))
 		return
 	}

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -192,7 +192,7 @@ func (p *Poller) handleWorkerResults(results []rpc.GetFullBlockResult) {
 			Traces:       result.Data.Traces,
 		})
 	}
-	if err := p.storage.StagingStorage.InsertBlockData(blockData); err != nil {
+	if err := p.storage.StagingStorage.InsertStagingData(blockData); err != nil {
 		e := fmt.Errorf("error inserting block data: %v", err)
 		log.Error().Err(e)
 		for _, result := range successfulResults {

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -41,19 +41,16 @@ type IOrchestratorStorage interface {
 }
 
 type IStagingStorage interface {
-	InsertBlockData(data []common.BlockData) error
-	GetBlockData(qf QueryFilter) (data []common.BlockData, err error)
-	DeleteBlockData(data []common.BlockData) error
+	InsertStagingData(data []common.BlockData) error
+	GetStagingData(qf QueryFilter) (data *[]common.BlockData, err error)
+	DeleteStagingData(data *[]common.BlockData) error
 	GetLastStagedBlockNumber(chainId *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error)
 }
 
 type IMainStorage interface {
-	InsertBlocks(blocks []common.Block) error
-	InsertTransactions(txs []common.Transaction) error
-	InsertLogs(logs []common.Log) error
-	InsertTraces(traces []common.Trace) error
+	InsertBlockData(data *[]common.BlockData) error
 
-	GetBlocks(qf QueryFilter) (logs []common.Block, err error)
+	GetBlocks(qf QueryFilter) (blocks []common.Block, err error)
 	GetTransactions(qf QueryFilter) (transactions QueryResult[common.Transaction], err error)
 	GetLogs(qf QueryFilter) (logs QueryResult[common.Log], err error)
 	GetTraces(qf QueryFilter) (traces []common.Trace, err error)


### PR DESCRIPTION
### TL;DR

Refactored data insertion process to allow the storage decide how to handle batched data. 
E.g sql databases can use transactions and concurrency whereas memory storage can do everything sequentially

### What changed?

- Introduced a new `InsertDataForBlocks` method in the `IMainStorage` interface.
- Removed individual insert methods for blocks, transactions, logs, and traces from the interface.
- Implemented `InsertDataForBlocks` in both ClickHouseConnector and MemoryConnector.
- Updated the Committer to use the new `InsertDataForBlocks` method instead of `saveDataToMainStorage`.
- Renamed insert methods in ClickHouseConnector and MemoryConnector to be private.
