### PR TITLE
Create storage functions for handling reorgs

### DIFF
--- a/internal/common/block.go
+++ b/internal/common/block.go
@@ -36,4 +36,10 @@ type BlockData struct {
 	Traces       []Trace
 }
 
+type BlockHeader struct {
+	Number     *big.Int `json:"number"`
+	Hash       string   `json:"hash"`
+	ParentHash string   `json:"parent_hash"`
+}
+
 type RawBlock = map[string]interface{}

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -38,6 +38,8 @@ type IOrchestratorStorage interface {
 	GetBlockFailures(qf QueryFilter) ([]common.BlockFailure, error)
 	StoreBlockFailures(failures []common.BlockFailure) error
 	DeleteBlockFailures(failures []common.BlockFailure) error
+	GetLastReorgCheckedBlockNumber(chainId *big.Int) (*big.Int, error)
+	SetLastReorgCheckedBlockNumber(chainId *big.Int, blockNumber *big.Int) error
 }
 
 type IStagingStorage interface {
@@ -55,6 +57,11 @@ type IMainStorage interface {
 	GetLogs(qf QueryFilter) (logs QueryResult[common.Log], err error)
 	GetTraces(qf QueryFilter) (traces []common.Trace, err error)
 	GetMaxBlockNumber(chainId *big.Int) (maxBlockNumber *big.Int, err error)
+	/**
+	 * Get block headers ordered from latest to oldest.
+	 */
+	LookbackBlockHeaders(chainId *big.Int, limit int, lookbackStart *big.Int) (blockHeaders []common.BlockHeader, err error)
+	DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) error
 }
 
 func NewStorageConnector(cfg *config.StorageConfig) (IStorage, error) {

--- a/internal/tools/clickhouse_create_cursors_table.sql
+++ b/internal/tools/clickhouse_create_cursors_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE cursors (
+    `chain_id` UInt256,
+    `cursor_type` String,
+    `cursor_value` String,
+    `insert_timestamp` DateTime DEFAULT now(),
+) ENGINE = ReplacingMergeTree(insert_timestamp)
+ORDER BY (chain_id, cursor_type);

--- a/internal/tools/clickhouse_create_staging_table.sql
+++ b/internal/tools/clickhouse_create_staging_table.sql
@@ -6,5 +6,5 @@ CREATE TABLE block_data (
     `is_deleted` UInt8 DEFAULT 0,
     INDEX idx_block_number block_number TYPE minmax GRANULARITY 1,
 ) ENGINE = ReplacingMergeTree(insert_timestamp, is_deleted)
-ORDER BY (chain_id, block_number) PRIMARY KEY (chain_id, block_number)
+ORDER BY (chain_id, block_number)
 SETTINGS allow_experimental_replacing_merge_with_cleanup = 1;


### PR DESCRIPTION
### TL;DR

Added support for chain reorganization detection and handling in the storage layer.

### What changed?

- Introduced a new `BlockHeader` struct in `block.go`
- Added methods to `ClickHouseConnector` for managing reorg checks and block headers
- Implemented `GetLastReorgCheckedBlockNumber` and `SetLastReorgCheckedBlockNumber` in storage connectors
- Added `LookbackBlockHeaders` and `DeleteDataForBlocks` methods to `IMainStorage` interface
- Updated `MemoryConnector` to support new reorg-related operations
- Added reorg check functionality to `RedisConnector`
- Created a new SQL script for a `cursors` table in ClickHouse
- Modified the staging table creation script to remove the primary key
