### PR TITLE
Refactor RPC client to use interface

### DIFF
--- a/cmd/orchestrator.go
+++ b/cmd/orchestrator.go
@@ -28,7 +28,7 @@ func RunOrchestrator(cmd *cobra.Command, args []string) {
 		log.Fatal().Err(err).Msg("Failed to initialize RPC")
 	}
 
-	orchestrator, err := orchestrator.NewOrchestrator(*rpc)
+	orchestrator, err := orchestrator.NewOrchestrator(rpc)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to create orchestrator")
 	}

--- a/internal/orchestrator/failure_recoverer.go
+++ b/internal/orchestrator/failure_recoverer.go
@@ -21,10 +21,10 @@ type FailureRecoverer struct {
 	failuresPerPoll   int
 	triggerIntervalMs int
 	storage           storage.IStorage
-	rpc               rpc.Client
+	rpc               rpc.IRPCClient
 }
 
-func NewFailureRecoverer(rpc rpc.Client, storage storage.IStorage) *FailureRecoverer {
+func NewFailureRecoverer(rpc rpc.IRPCClient, storage storage.IStorage) *FailureRecoverer {
 	failuresPerPoll := config.Cfg.FailureRecoverer.BlocksPerRun
 	if failuresPerPoll == 0 {
 		failuresPerPoll = DEFAULT_FAILURES_PER_POLL
@@ -49,7 +49,7 @@ func (fr *FailureRecoverer) Start() {
 	go func() {
 		for range ticker.C {
 			blockFailures, err := fr.storage.OrchestratorStorage.GetBlockFailures(storage.QueryFilter{
-				ChainId: fr.rpc.ChainID,
+				ChainId: fr.rpc.GetChainID(),
 				Limit:   fr.failuresPerPoll,
 			})
 			if err != nil {
@@ -101,7 +101,7 @@ func (fr *FailureRecoverer) handleWorkerResults(blockFailures []common.BlockFail
 				BlockNumber:   result.BlockNumber,
 				FailureReason: result.Error.Error(),
 				FailureTime:   time.Now(),
-				ChainId:       fr.rpc.ChainID,
+				ChainId:       fr.rpc.GetChainID(),
 				FailureCount:  failureCount,
 			})
 		} else {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Orchestrator struct {
-	rpc                     rpc.Client
+	rpc                     rpc.IRPCClient
 	storage                 storage.IStorage
 	pollerEnabled           bool
 	failureRecovererEnabled bool
@@ -17,7 +17,7 @@ type Orchestrator struct {
 	reorgHandlerEnabled     bool
 }
 
-func NewOrchestrator(rpc rpc.Client) (*Orchestrator, error) {
+func NewOrchestrator(rpc rpc.IRPCClient) (*Orchestrator, error) {
 	storage, err := storage.NewStorageConnector(&config.Cfg.Storage)
 	if err != nil {
 		return nil, err

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -13,10 +13,10 @@ import (
 )
 
 type Worker struct {
-	rpc rpc.Client
+	rpc rpc.IRPCClient
 }
 
-func NewWorker(rpc rpc.Client) *Worker {
+func NewWorker(rpc rpc.IRPCClient) *Worker {
 	return &Worker{
 		rpc: rpc,
 	}
@@ -24,12 +24,12 @@ func NewWorker(rpc rpc.Client) *Worker {
 
 func (w *Worker) Run(blockNumbers []*big.Int) []rpc.GetFullBlockResult {
 	blockCount := len(blockNumbers)
-	chunks := common.BigIntSliceToChunks(blockNumbers, w.rpc.BlocksPerRequest.Blocks)
+	chunks := common.BigIntSliceToChunks(blockNumbers, w.rpc.GetBlocksPerRequest().Blocks)
 
 	var wg sync.WaitGroup
 	resultsCh := make(chan []rpc.GetFullBlockResult, len(chunks))
 
-	log.Debug().Msgf("Worker Processing %d blocks in %d chunks of max %d blocks", blockCount, len(chunks), w.rpc.BlocksPerRequest.Blocks)
+	log.Debug().Msgf("Worker Processing %d blocks in %d chunks of max %d blocks", blockCount, len(chunks), w.rpc.GetBlocksPerRequest().Blocks)
 	for _, chunk := range chunks {
 		wg.Add(1)
 		go func(chunk []*big.Int) {


### PR DESCRIPTION
### TL;DR

Refactored RPC client interface and updated related components for improved modularity and testability.

### What changed?

- Introduced `IRPCClient` interface in `rpc.go` to abstract RPC client functionality.
- Updated `Client` struct to implement `IRPCClient` interface.
- Modified `Initialize()` function to return `IRPCClient` instead of `*Client`.
- Refactored `Orchestrator`, `ChainTracker`, `Committer`, `FailureRecoverer`, `Poller`, `ReorgHandler`, and `Worker` to use `IRPCClient` interface.
- Moved `GetLatestBlockNumber()` method from `Poller` to `Client`.
- Updated method calls and field accesses throughout the codebase to use the new interface.

### How to test?

1. Ensure indexing works after the refactoring.

### Why make this change?

This refactoring improves the codebase by:

1. Enhancing modularity and separation of concerns.
2. Facilitating easier testing by allowing mock implementations of `IRPCClient`.
3. Improving code maintainability and readability.
4. Providing a clearer contract for RPC client functionality.
5. Enabling easier future extensions or modifications to the RPC client implementation.