### PR TITLE
Add configurable API host and update Swagger documentation

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -12,7 +12,8 @@ import (
 	"github.com/thirdweb-dev/indexer/internal/middleware"
 
 	// Import the generated Swagger docs
-	_ "github.com/thirdweb-dev/indexer/docs"
+	config "github.com/thirdweb-dev/indexer/configs"
+	"github.com/thirdweb-dev/indexer/docs"
 )
 
 var (
@@ -31,11 +32,12 @@ var (
 // @description API for querying blockchain transactions and events
 // @license.name Apache 2.0
 // @license.url https://github.com/thirdweb-dev/indexer/blob/main/LICENSE
-// @host localhost:3000
 // @BasePath /
 // @Security BasicAuth
 // @securityDefinitions.basic BasicAuth
 func RunApi(cmd *cobra.Command, args []string) {
+	docs.SwaggerInfo.Host = config.Cfg.API.Host
+
 	r := gin.New()
 	r.Use(gin.Logger())
 	r.Use(gin.Recovery())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func init() {
 	rootCmd.PersistentFlags().String("storage-main-clickhouse-password", "", "Clickhouse password for main storage")
 	rootCmd.PersistentFlags().String("storage-staging-clickhouse-username", "", "Clickhouse username for staging storage")
 	rootCmd.PersistentFlags().String("storage-staging-clickhouse-password", "", "Clickhouse password for staging storage")
+	rootCmd.PersistentFlags().String("api-host", "localhost:3000", "API host")
 	viper.BindPFlag("rpc.url", rootCmd.PersistentFlags().Lookup("rpc-url"))
 	viper.BindPFlag("rpc.blocks.blocksPerRequest", rootCmd.PersistentFlags().Lookup("rpc-blocks-blocksPerRequest"))
 	viper.BindPFlag("rpc.blocks.batchDelay", rootCmd.PersistentFlags().Lookup("rpc-blocks-batchDelay"))
@@ -120,6 +121,7 @@ func init() {
 	viper.BindPFlag("storage.orchestrator.redis.addr", rootCmd.PersistentFlags().Lookup("storage-orchestrator-redis-addr"))
 	viper.BindPFlag("storage.orchestrator.redis.password", rootCmd.PersistentFlags().Lookup("storage-orchestrator-redis-password"))
 	viper.BindPFlag("storage.orchestrator.redis.db", rootCmd.PersistentFlags().Lookup("storage-orchestrator-redis-db"))
+	viper.BindPFlag("api.host", rootCmd.PersistentFlags().Lookup("api-host"))
 	rootCmd.AddCommand(orchestratorCmd)
 	rootCmd.AddCommand(apiCmd)
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -91,6 +91,10 @@ type RPCConfig struct {
 	Traces RPCTracesConfig    `mapstructure:"traces"`
 }
 
+type APIConfig struct {
+	Host string `mapstructure:"host"`
+}
+
 type Config struct {
 	RPC              RPCConfig              `mapstructure:"rpc"`
 	Log              LogConfig              `mapstructure:"log"`
@@ -98,6 +102,7 @@ type Config struct {
 	Committer        CommitterConfig        `mapstructure:"committer"`
 	FailureRecoverer FailureRecovererConfig `mapstructure:"failureRecoverer"`
 	Storage          StorageConfig          `mapstructure:"storage"`
+	API              APIConfig              `mapstructure:"api"`
 }
 
 var Cfg Config

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -954,7 +954,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "v0.0.1-beta",
-	Host:             "localhost:3000",
+	Host:             "",
 	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "Thirdweb Insight",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -10,7 +10,6 @@
         },
         "version": "v0.0.1-beta"
     },
-    "host": "localhost:3000",
     "basePath": "/",
     "paths": {
         "/{chainId}/events": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -121,7 +121,6 @@ definitions:
       value:
         type: string
     type: object
-host: localhost:3000
 info:
   contact: {}
   description: API for querying blockchain transactions and events


### PR DESCRIPTION
### TL;DR

Added configurable API host for Swagger documentation and improved API configuration.

### What changed?

- Introduced a new `APIConfig` struct in `configs/config.go` with a `Host` field.
- Added a new command-line flag `--api-host` in `cmd/root.go` with a default value of "localhost:3000".
- Updated `cmd/api.go` to set the Swagger host dynamically using the configured API host.
- Removed the hardcoded host from `docs/docs.go`, `docs/swagger.json`, and `docs/swagger.yaml`.

### How to test?

1. Run the API with a custom host:
   ```
   ./indexer api --api-host example.com:8080
   ```
2. Check the Swagger documentation to ensure the host is set correctly.

### Why make this change?

This change allows for greater flexibility in deploying the API to different environments. By making the API host configurable, it becomes easier to adapt the service to various deployment scenarios without modifying the code. This is particularly useful for staging, production, and custom deployment setups.