### PR TITLE
Improve poller block range handling and staging data retrieval

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -516,10 +516,13 @@ func (c *ClickHouseConnector) GetMaxBlockNumber(chainId *big.Int) (maxBlockNumbe
 	return maxBlockNumber, nil
 }
 
-func (c *ClickHouseConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error) {
+func (c *ClickHouseConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error) {
 	query := fmt.Sprintf("SELECT block_number FROM %s.block_data WHERE is_deleted = 0", c.cfg.Database)
 	if chainId.Sign() > 0 {
 		query += fmt.Sprintf(" AND chain_id = %s", chainId.String())
+	}
+	if rangeStart.Sign() > 0 {
+		query += fmt.Sprintf(" AND block_number >= %s", rangeStart.String())
 	}
 	if rangeEnd.Sign() > 0 {
 		query += fmt.Sprintf(" AND block_number <= %s", rangeEnd.String())

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -46,7 +46,7 @@ type IStagingStorage interface {
 	InsertStagingData(data []common.BlockData) error
 	GetStagingData(qf QueryFilter) (data *[]common.BlockData, err error)
 	DeleteStagingData(data *[]common.BlockData) error
-	GetLastStagedBlockNumber(chainId *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error)
+	GetLastStagedBlockNumber(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error)
 }
 
 type IMainStorage interface {

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -194,14 +194,14 @@ func (m *MemoryConnector) GetMaxBlockNumber(chainId *big.Int) (*big.Int, error) 
 	return maxBlockNumber, nil
 }
 
-func IsInRange(num *big.Int, rangeEnd *big.Int) bool {
+func IsInRange(num *big.Int, rangeStart *big.Int, rangeEnd *big.Int) bool {
 	if rangeEnd.Sign() == 0 {
 		return true
 	}
-	return num.Cmp(rangeEnd) <= 0
+	return num.Cmp(rangeStart) >= 0 && num.Cmp(rangeEnd) <= 0
 }
 
-func (m *MemoryConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeEnd *big.Int) (*big.Int, error) {
+func (m *MemoryConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int) (*big.Int, error) {
 	maxBlockNumber := new(big.Int)
 	for _, key := range m.cache.Keys() {
 		if strings.HasPrefix(key, fmt.Sprintf("blockData:%s:", chainId.String())) {
@@ -210,7 +210,7 @@ func (m *MemoryConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeEnd *b
 			if !ok {
 				return nil, fmt.Errorf("failed to parse block number: %s", blockNumberStr)
 			}
-			if blockNumber.Cmp(maxBlockNumber) > 0 && IsInRange(blockNumber, rangeEnd) {
+			if blockNumber.Cmp(maxBlockNumber) > 0 && IsInRange(blockNumber, rangeStart, rangeEnd) {
 				maxBlockNumber = blockNumber
 			}
 		}

--- a/test/mocks/MockIStagingStorage.go
+++ b/test/mocks/MockIStagingStorage.go
@@ -72,9 +72,9 @@ func (_c *MockIStagingStorage_DeleteStagingData_Call) RunAndReturn(run func(*[]c
 	return _c
 }
 
-// GetLastStagedBlockNumber provides a mock function with given fields: chainId, rangeEnd
-func (_m *MockIStagingStorage) GetLastStagedBlockNumber(chainId *big.Int, rangeEnd *big.Int) (*big.Int, error) {
-	ret := _m.Called(chainId, rangeEnd)
+// GetLastStagedBlockNumber provides a mock function with given fields: chainId, rangeStart, rangeEnd
+func (_m *MockIStagingStorage) GetLastStagedBlockNumber(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int) (*big.Int, error) {
+	ret := _m.Called(chainId, rangeStart, rangeEnd)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLastStagedBlockNumber")
@@ -82,19 +82,19 @@ func (_m *MockIStagingStorage) GetLastStagedBlockNumber(chainId *big.Int, rangeE
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int) (*big.Int, error)); ok {
-		return rf(chainId, rangeEnd)
+	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int, *big.Int) (*big.Int, error)); ok {
+		return rf(chainId, rangeStart, rangeEnd)
 	}
-	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int) *big.Int); ok {
-		r0 = rf(chainId, rangeEnd)
+	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int, *big.Int) *big.Int); ok {
+		r0 = rf(chainId, rangeStart, rangeEnd)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*big.Int, *big.Int) error); ok {
-		r1 = rf(chainId, rangeEnd)
+	if rf, ok := ret.Get(1).(func(*big.Int, *big.Int, *big.Int) error); ok {
+		r1 = rf(chainId, rangeStart, rangeEnd)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -109,14 +109,15 @@ type MockIStagingStorage_GetLastStagedBlockNumber_Call struct {
 
 // GetLastStagedBlockNumber is a helper method to define mock.On call
 //   - chainId *big.Int
+//   - rangeStart *big.Int
 //   - rangeEnd *big.Int
-func (_e *MockIStagingStorage_Expecter) GetLastStagedBlockNumber(chainId interface{}, rangeEnd interface{}) *MockIStagingStorage_GetLastStagedBlockNumber_Call {
-	return &MockIStagingStorage_GetLastStagedBlockNumber_Call{Call: _e.mock.On("GetLastStagedBlockNumber", chainId, rangeEnd)}
+func (_e *MockIStagingStorage_Expecter) GetLastStagedBlockNumber(chainId interface{}, rangeStart interface{}, rangeEnd interface{}) *MockIStagingStorage_GetLastStagedBlockNumber_Call {
+	return &MockIStagingStorage_GetLastStagedBlockNumber_Call{Call: _e.mock.On("GetLastStagedBlockNumber", chainId, rangeStart, rangeEnd)}
 }
 
-func (_c *MockIStagingStorage_GetLastStagedBlockNumber_Call) Run(run func(chainId *big.Int, rangeEnd *big.Int)) *MockIStagingStorage_GetLastStagedBlockNumber_Call {
+func (_c *MockIStagingStorage_GetLastStagedBlockNumber_Call) Run(run func(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int)) *MockIStagingStorage_GetLastStagedBlockNumber_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*big.Int), args[1].(*big.Int))
+		run(args[0].(*big.Int), args[1].(*big.Int), args[2].(*big.Int))
 	})
 	return _c
 }
@@ -126,7 +127,7 @@ func (_c *MockIStagingStorage_GetLastStagedBlockNumber_Call) Return(maxBlockNumb
 	return _c
 }
 
-func (_c *MockIStagingStorage_GetLastStagedBlockNumber_Call) RunAndReturn(run func(*big.Int, *big.Int) (*big.Int, error)) *MockIStagingStorage_GetLastStagedBlockNumber_Call {
+func (_c *MockIStagingStorage_GetLastStagedBlockNumber_Call) RunAndReturn(run func(*big.Int, *big.Int, *big.Int) (*big.Int, error)) *MockIStagingStorage_GetLastStagedBlockNumber_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR

Improved block polling logic and updated storage interfaces for more precise block range handling.

### What changed?

- Modified `Poller` initialization to handle `ForceFromBlock` configuration more effectively.
- Updated `GetLastStagedBlockNumber` method in storage interfaces to include a `rangeStart` parameter.
- Adjusted ClickHouse and memory storage implementations to support the new `rangeStart` parameter.
- Updated mock storage interface to reflect the changes in the `GetLastStagedBlockNumber` method.

### How to test?

1. Verify that the poller initializes correctly with different `ForceFromBlock` configurations.
2. Test the `GetLastStagedBlockNumber` method with various range start and end values.
3. Ensure that the ClickHouse and memory storage implementations correctly filter blocks within the specified range.
4. Update and run existing tests that use the mock storage interface to accommodate the new parameter.

### Why make this change?

This change improves the flexibility and precision of block polling and storage operations. By introducing a `rangeStart` parameter, we can more accurately retrieve and manage block data within specific ranges. This is particularly useful for scenarios where we need to re-poll from a specific start block or handle gaps in block data more effectively.