### PR TITLE
Update Docker image tagging in release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,7 +27,8 @@ jobs:
         with:
           images: ${{ vars.DOCKER_IMAGE }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable={{github.event_name == 'workflow_dispatch'}}
+            type=semver,pattern={{version}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
### TL;DR

Updated Docker image tagging strategy in the release workflow.

### What changed?

- Modified the tagging logic for the Docker image in the `docker-release.yml` workflow.
- Changed the condition for the `latest` tag to be applied only when the workflow is manually triggered.
- Added a new tag using semantic versioning pattern.

### How to test?

1. Manually trigger the workflow to verify the `latest` tag is applied.
2. Create a new release with a semantic version (e.g., v1.2.3) to confirm the new versioning tag is correctly applied.
3. Check the Docker registry to ensure the images are tagged as expected.

### Why make this change?

This change provides more control over when the `latest` tag is applied and introduces semantic versioning for better version management of Docker images. It allows for more precise tracking of image versions and ensures the `latest` tag is only updated when explicitly desired through manual workflow triggers.