### PR TITLE
Don't cut bytes from non-address topics + account for empty topics

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -456,10 +456,16 @@ func addContractAddress(table, query string, contractAddress string) string {
 }
 
 func getTopicValueFormat(topic string) string {
-	toAddressHex := ethereum.HexToAddress(topic)
-	toAddressPadded := ethereum.LeftPadBytes(toAddressHex.Bytes(), 32)
-	toAddressTopic := ethereum.BytesToHash(toAddressPadded).Hex()
-	return toAddressTopic
+	if topic == "" {
+		// if there is no indexed topic, indexer stores an empty string
+		// we shouldn't pad and hexify such an argument then
+		return ""
+	}
+	asBytes := ethereum.FromHex(topic)
+	// ensure the byte slice is exactly 32 bytes by left-padding with zeros
+	asPadded := ethereum.LeftPadBytes(asBytes, 32)
+	result := ethereum.BytesToHash(asPadded).Hex()
+	return result
 }
 
 func (c *ClickHouseConnector) executeAggregateQuery(table string, qf QueryFilter) (map[string]string, error) {


### PR DESCRIPTION
### TL;DR

Improved handling of topic values in the `getTopicValueFormat` function.

### What changed?

- Modified the `getTopicValueFormat` function to handle empty topic strings.
- Updated the logic for processing non-empty topics:
  - Now uses `ethereum.FromHex` to convert the topic to bytes
    - ⚠️ prev. used `ethereum.HexToAddress` was wrong in this context cause topics are not necessarily addresses)
  - Ensures the byte slice is exactly 32 bytes by left-padding with zeros.
  - Converts the padded bytes to a hash and returns the hexadecimal representation.

### How to test?

1. Test the function with an empty string input to ensure it returns an empty string.
2. Test with various non-empty topic strings, including:
   - Short strings (less than 32 bytes)
   - Exactly 32-byte strings
   - Strings longer than 32 bytes
3. Verify that the output is always a 32-byte hexadecimal string (or empty for empty input).

### Why make this change?

This change improves the robustness of topic value handling:
- It correctly handles empty topics, which are stored as empty strings by the indexer.
- It ensures consistent 32-byte padding for all non-empty topics, regardless of their original length.
- This approach aligns better with Ethereum's topic encoding standards, potentially fixing issues related to topic matching or filtering.