### PR TITLE
Skip unmerged blocks in reorg handler

### DIFF
--- a/internal/orchestrator/reorg_handler.go
+++ b/internal/orchestrator/reorg_handler.go
@@ -125,6 +125,9 @@ func findReorgEndIndex(reversedBlockHeaders []common.BlockHeader) (index int) {
 		currentBlock := reversedBlockHeaders[i]
 		previousBlock := reversedBlockHeaders[i+1]
 
+		if currentBlock.Number.Cmp(previousBlock.Number) == 0 { // unmerged block
+			continue
+		}
 		if currentBlock.ParentHash != previousBlock.Hash {
 			log.Debug().
 				Str("currentBlockNumber", currentBlock.Number.String()).


### PR DESCRIPTION
### TL;DR
Added support for handling duplicate blocks during chain reorganization detection.

### What changed?
- Added a check in `findReorgEndIndex` to skip blocks with the same block number during reorg detection
- Added test cases to verify handling of duplicate blocks and correct block sequences
- Improved reorg detection logic to handle unmerged blocks in the chain

### How to test?
1. Run the new test cases:
   - `TestHandleReorgWithDuplicateBlocks`
   - `TestNothingIsDoneForCorrectBlocks`
2. Verify that duplicate blocks are properly handled and don't trigger false reorg detections
3. Confirm that correct block sequences continue to work as expected

### Why make this change?
When processing block headers, duplicate blocks with the same block number can appear if there are multiple committers running by mistake. Usually clickhouse will merge these duplicates in the background, but these duplicates should not trigger reorg handling, as they represent unmerged blocks rather than actual chain reorganizations. This change ensures more accurate reorg detection by properly handling these edge cases.