### PR TITLE
Update Docker image tagging in release workflow

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           images: ${{ vars.DOCKER_IMAGE }}
           tags: |
-            type=raw,value=latest,enable={{github.event_name == 'workflow_dispatch'}}
+            type=raw,value=latest
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
### TL;DR

Updated Docker image tagging strategy in the release workflow.

### What changed?

Modified the `docker-release.yml` workflow file to always tag the Docker image with `latest`, regardless of the event that triggered the workflow. 

### How to test?

1. Trigger the Docker release workflow through any supported event (e.g., manual dispatch).
2. Verify that the built Docker image is tagged with both `latest` and the semantic version.

### Why make this change?

This change ensures that the `latest` tag is consistently applied to the most recent Docker image build, improving version tracking and making it easier for users to always pull the most up-to-date image without specifying a specific version.