### PR TITLE
use lightweight deletes

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -1003,7 +1003,7 @@ func (c *ClickHouseConnector) DeleteBlockData(chainId *big.Int, blockNumbers []*
 }
 
 func (c *ClickHouseConnector) deleteBatch(chainId *big.Int, blockNumbers []*big.Int, table string, blockNumberColumn string) error {
-	query := fmt.Sprintf("ALTER TABLE %s.%s DELETE WHERE chain_id = ? AND %s IN (?)", c.cfg.Database, table, blockNumberColumn)
+	query := fmt.Sprintf("DELETE FROM %s.%s WHERE chain_id = ? AND %s IN (?)", c.cfg.Database, table, blockNumberColumn)
 
 	blockNumbersStr := make([]string, len(blockNumbers))
 	for i, bn := range blockNumbers {


### PR DESCRIPTION
### TL;DR
Updated the DELETE query syntax in ClickHouse to use lightweight DELETE FROM instead of ALTER TABLE DELETE.

### What changed?
Modified the query string in the `deleteBatch` function to use `DELETE FROM` syntax instead of `ALTER TABLE DELETE` when removing data from ClickHouse tables.

### How to test?
1. Execute delete operations on ClickHouse tables
2. Verify that records are successfully deleted
3. Check that the operation completes without any syntax errors

### Why make this change?
The `ALTER TABLE DELETE` syntax is deprecated in newer versions of ClickHouse. Using `DELETE FROM` is the standard and recommended approach for delete operations, ensuring better compatibility and maintainability.