### PR TITLE
fix invalid safeguard for solidity types

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -143,21 +143,10 @@ func cleanType(param string) string {
 
 // isType checks if a word is a Solidity type
 func isType(word string) bool {
+	if strings.HasPrefix(word, "uint") || strings.HasPrefix(word, "int") {
+		return true
+	}
 	types := map[string]bool{
-		"uint":     true,
-		"int":      true,
-		"uint8":    true,
-		"int8":     true,
-		"uint16":   true,
-		"int16":    true,
-		"uint32":   true,
-		"int32":    true,
-		"uint64":   true,
-		"int64":    true,
-		"uint128":  true,
-		"int128":   true,
-		"uint256":  true,
-		"int256":   true,
 		"address":  true,
 		"bool":     true,
 		"string":   true,


### PR DESCRIPTION
### TL;DR
Fixed Solidity type checking by using string prefix matching for integer types.

### What changed?
Replaced explicit mapping of integer types (uint8, int16, etc.) with a prefix check for "uint" and "int". Non-integer types like address, bool, and string remain in the map.

### How to test?
1. Test type checking with various integer types (uint8, int256, etc.)
2. Verify that non-integer types (address, bool, string) are still correctly identified
3. Ensure negative cases (non-types) return false

### Why make this change?
The previous implementation listed every possible integer type explicitly, which was verbose and harder to maintain. Uints and ints can be in 8 byte increments.