### PR TITLE
Fix force range for reorg checks

### DIFF
--- a/internal/orchestrator/reorg_handler.go
+++ b/internal/orchestrator/reorg_handler.go
@@ -102,7 +102,12 @@ func (rh *ReorgHandler) RunFromBlock(lookbackFrom *big.Int) (lastCheckedBlock *b
 		return nil, nil
 	}
 	mostRecentBlockHeader := blockHeaders[0]
-	log.Debug().Msgf("Checking for reorgs from block %s to %s", mostRecentBlockHeader.Number.String(), blockHeaders[len(blockHeaders)-1].Number.String())
+	lastBlockHeader := blockHeaders[len(blockHeaders)-1]
+	if mostRecentBlockHeader.Number.Cmp(lastBlockHeader.Number) == 0 {
+		log.Debug().Msgf("Most recent (%s) and last checked (%s) block numbers are equal, skipping reorg check", mostRecentBlockHeader.Number.String(), lastBlockHeader.Number.String())
+		return nil, nil
+	}
+	log.Debug().Msgf("Checking for reorgs from block %s to %s", mostRecentBlockHeader.Number.String(), lastBlockHeader.Number.String())
 	reorgEndIndex := findReorgEndIndex(blockHeaders)
 	if reorgEndIndex == -1 {
 		return mostRecentBlockHeader.Number, nil

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -932,7 +932,8 @@ func (c *ClickHouseConnector) SetLastReorgCheckedBlockNumber(chainId *big.Int, b
 }
 
 func (c *ClickHouseConnector) LookbackBlockHeaders(chainId *big.Int, limit int, lookbackStart *big.Int) (blockHeaders []common.BlockHeader, err error) {
-	query := fmt.Sprintf("SELECT number, hash, parent_hash FROM %s.blocks WHERE chain_id = %s AND number <= %s AND is_deleted = 0 ORDER BY number DESC", c.cfg.Database, chainId.String(), lookbackStart.String())
+	lookbackEnd := new(big.Int).Sub(lookbackStart, big.NewInt(int64(limit)))
+	query := fmt.Sprintf("SELECT number, hash, parent_hash FROM %s.blocks WHERE chain_id = %s AND number <= %s AND number > %s AND is_deleted = 0 ORDER BY number DESC", c.cfg.Database, chainId.String(), lookbackStart.String(), lookbackEnd.String())
 	query += getLimitClause(limit)
 
 	rows, err := c.conn.Query(context.Background(), query)


### PR DESCRIPTION
### TL;DR
Added block range validation and optimized block header queries to prevent unnecessary reorg checks.

### What changed?
- Added validation to skip reorg checks when the most recent and last checked block numbers are equal
- Modified the `LookbackBlockHeaders` query to include a lower bound on block numbers, creating a specific range for querying
- Enhanced logging to better indicate when reorg checks are skipped

### How to test?
1. Run the system with chain monitoring enabled
2. Verify logs show skipped reorg checks when blocks are equal
3. Confirm block header queries return results only within the specified range
4. Validate that reorg detection still functions correctly for actual reorgs

### Why make this change?
The previous implementation would perform unnecessary reorg checks when block numbers were identical and could potentially query more blocks than needed. These changes improve efficiency by avoiding redundant operations and limiting the query scope to only relevant block ranges.