### PR TITLE
use partition ids with lightweight delete

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -1004,14 +1004,14 @@ func (c *ClickHouseConnector) DeleteBlockData(chainId *big.Int, blockNumbers []*
 }
 
 func (c *ClickHouseConnector) deleteBatch(chainId *big.Int, blockNumbers []*big.Int, table string, blockNumberColumn string) error {
-	query := fmt.Sprintf("DELETE FROM %s.%s WHERE chain_id = ? AND %s IN (?)", c.cfg.Database, table, blockNumberColumn)
+	query := fmt.Sprintf("DELETE FROM %s.%s WHERE _partition_id = ? AND chain_id = ? AND %s IN (?)", c.cfg.Database, table, blockNumberColumn)
 
 	blockNumbersStr := make([]string, len(blockNumbers))
 	for i, bn := range blockNumbers {
 		blockNumbersStr[i] = bn.String()
 	}
 
-	err := c.conn.Exec(context.Background(), query, chainId, blockNumbersStr)
+	err := c.conn.Exec(context.Background(), query, chainId, chainId, blockNumbersStr)
 	if err != nil {
 		return fmt.Errorf("error deleting from %s: %w", table, err)
 	}


### PR DESCRIPTION
### TL;DR

Added `_partition_id` to DELETE query in ClickHouse connector to optimize data deletion operations.

### What changed?
Modified the `deleteBatch` function to include `_partition_id` in the DELETE query's WHERE clause. The partition ID is now set to match the chain_id, which helps ClickHouse identify the specific partition for deletion.

### How to test?
1. Execute DELETE operations on ClickHouse tables using the connector
2. Verify that deletions complete successfully
3. Check query performance metrics to confirm improved deletion efficiency
4. Ensure data integrity is maintained across different chain IDs

### Why make this change?
ClickHouse performs better when DELETE operations include partition information. By adding the `_partition_id` to the query, we enable ClickHouse to quickly identify and remove data from specific partitions instead of scanning the entire table, resulting in more efficient delete operations.