### PR TITLE
fix: substring correctly

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -493,9 +493,9 @@ func addFilterParams(key, value, query string) string {
 	suffix := key[len(key)-3:]
 	switch suffix {
 	case "gte":
-		query += fmt.Sprintf(" AND %s >= '%s'", key[:len(key)-3], value)
+		query += fmt.Sprintf(" AND %s >= '%s'", key[:len(key)-4], value)
 	case "lte":
-		query += fmt.Sprintf(" AND %s <= '%s'", key[:len(key)-3], value)
+		query += fmt.Sprintf(" AND %s <= '%s'", key[:len(key)-4], value)
 	case "_lt":
 		query += fmt.Sprintf(" AND %s < '%s'", key[:len(key)-3], value)
 	case "_gt":


### PR DESCRIPTION
### TL;DR
Fixed incorrect string slicing in ClickHouse filter parameters for 'gte' and 'lte' conditions.

### What changed?
Modified the string slicing length in `addFilterParams` function from `-3` to `-4` for 'gte' and 'lte' suffixes to properly extract the base column name from filter parameters.

### How to test?
1. Execute queries using filters with 'gte' and 'lte' suffixes
2. Verify that the generated SQL queries contain the correct column names
3. Confirm that filter conditions are properly applied to the results

### Why make this change?
The previous implementation was incorrectly slicing the column names for 'gte' and 'lte' conditions, which could lead to malformed SQL queries. This fix ensures proper column name extraction and maintains consistency with the filter parameter naming convention.