### PR TITLE
Allow toStartOfDay and toDate functions in the API

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -170,6 +170,8 @@ var allowedFunctions = map[string]struct{}{
 	"length":               {},
 	"toUInt256":            {},
 	"if":                   {},
+	"toStartOfDay":         {},
+	"toDate":               {},
 }
 
 var disallowedPatterns = []string{


### PR DESCRIPTION
### TL;DR
Added support for `toStartOfDay` and `toDate` functions in the allowed functions map.

### What changed?
Added two new date-related functions (`toStartOfDay` and `toDate`) to the `allowedFunctions` map, enabling their use within the application.

### How to test?
1. Use the `toStartOfDay` function in expressions to convert a timestamp to the start of its day
2. Use the `toDate` function to convert timestamps to date format
3. Verify that both functions execute without permission errors

### Why make this change?
To enable date manipulation capabilities within the application, allowing users to perform date-based operations and transformations when working with timestamp data.