### PR TITLE
whitelist concat function

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -172,6 +172,7 @@ var allowedFunctions = map[string]struct{}{
 	"if":                   {},
 	"toStartOfDay":         {},
 	"toDate":               {},
+	"concat":               {},
 }
 
 var disallowedPatterns = []string{


### PR DESCRIPTION
### TL;DR
Added support for the `concat` function in the allowed functions list.

### What changed?
Added the `concat` function to the `allowedFunctions` map, enabling string concatenation operations.

### How to test?
1. Use the `concat` function in your queries or templates
2. Verify that the function executes without permission errors
3. Confirm that string concatenation works as expected

### Why make this change?
String concatenation is a fundamental operation needed for data manipulation and string formatting. Adding the `concat` function provides users with the ability to combine strings dynamically within their queries or templates.