### PR TITLE
allow more date functions and ordering for aggregations

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -170,7 +170,10 @@ var allowedFunctions = map[string]struct{}{
 	"length":               {},
 	"toUInt256":            {},
 	"if":                   {},
+	"toStartOfMonth":       {},
 	"toStartOfDay":         {},
+	"toStartOfHour":        {},
+	"toStartOfMinute":      {},
 	"toDate":               {},
 	"concat":               {},
 }

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -373,6 +373,11 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 		query += fmt.Sprintf(" GROUP BY %s", groupByColumns)
 	}
 
+	// Add ORDER BY clause
+	if qf.SortBy != "" {
+		query += fmt.Sprintf(" ORDER BY %s %s", qf.SortBy, qf.SortOrder)
+	}
+
 	if err := common.ValidateQuery(query); err != nil {
 		return QueryResult[interface{}]{}, err
 	}


### PR DESCRIPTION
### TL;DR
Added new time-based functions to the allowed functions map: `toStartOfMonth`, `toStartOfHour`, and `toStartOfMinute`

Added support for ordering aggregation results

### What changed?
Extended the `allowedFunctions` map to include three new time manipulation functions:
- `toStartOfMonth`: Truncates a timestamp to the start of its month
- `toStartOfHour`: Truncates a timestamp to the start of its hour
- `toStartOfMinute`: Truncates a timestamp to the start of its minute

### Why make this change?
To provide more granular time-based aggregation options for queries, allowing users to group and analyze data at month, hour, and minute levels alongside the existing day-level functionality.