### PR TITLE
feat: get blocks API handle

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -73,6 +73,9 @@ func RunApi(cmd *cobra.Command, args []string) {
 		// signature scoped queries
 		root.GET("/transactions/:to/:signature", handlers.GetTransactionsByContractAndSignature)
 		root.GET("/events/:contract/:signature", handlers.GetLogsByContractAndSignature)
+
+		// blocks table queries
+		root.GET("/blocks", handlers.GetBlocks)
 	}
 
 	r.GET("/health", func(c *gin.Context) {

--- a/internal/handlers/blocks_handlers.go
+++ b/internal/handlers/blocks_handlers.go
@@ -1,0 +1,126 @@
+package handlers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/thirdweb-dev/indexer/api"
+	"github.com/thirdweb-dev/indexer/internal/storage"
+)
+
+// BlockModel represents a simplified Block structure for Swagger documentation
+type BlockModel struct {
+	ChainId         string `json:"chain_id"`
+	Number          string `json:"number"`
+	Hash            string `json:"hash"`
+	ParentHash      string `json:"parent_hash"`
+	Timestamp       uint64 `json:"timestamp"`
+	Nonce           string `json:"nonce"`
+	Sha3Uncles      string `json:"sha3_uncles"`
+	LogsBloom       string `json:"logs_bloom"`
+	ReceiptsRoot    string `json:"receipts_root"`
+	Difficulty      string `json:"difficulty"`
+	TotalDifficulty string `json:"total_difficulty"`
+	Size            uint64 `json:"size"`
+	ExtraData       string `json:"extra_data"`
+	GasLimit        uint64 `json:"gas_limit"`
+	GasUsed         uint64 `json:"gas_used"`
+	BaseFeePerGas   string `json:"base_fee_per_gas"`
+	WithdrawalsRoot string `json:"withdrawals_root"`
+}
+
+// @Summary Get all blocks
+// @Description Retrieve all blocks
+// @Tags blocks
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param chainId path string true "Chain ID"
+// @Param filter query string false "Filter parameters"
+// @Param group_by query string false "Field to group results by"
+// @Param sort_by query string false "Field to sort results by"
+// @Param sort_order query string false "Sort order (asc or desc)"
+// @Param page query int false "Page number for pagination"
+// @Param limit query int false "Number of items per page" default(5)
+// @Param aggregate query []string false "List of aggregate functions to apply"
+// @Success 200 {object} api.QueryResponse{data=[]BlockModel}
+// @Failure 400 {object} api.Error
+// @Failure 401 {object} api.Error
+// @Failure 500 {object} api.Error
+// @Router /{chainId}/blocks [get]
+func GetBlocks(c *gin.Context) {
+	handleBlocksRequest(c)
+}
+
+func handleBlocksRequest(c *gin.Context) {
+	chainId, err := api.GetChainId(c)
+	if err != nil {
+		api.BadRequestErrorHandler(c, err)
+		return
+	}
+
+	queryParams, err := api.ParseQueryParams(c.Request)
+	if err != nil {
+		api.BadRequestErrorHandler(c, err)
+		return
+	}
+
+	mainStorage, err := getMainStorage()
+	if err != nil {
+		log.Error().Err(err).Msg("Error getting main storage")
+		api.InternalErrorHandler(c)
+		return
+	}
+
+	// Prepare the QueryFilter
+	qf := storage.QueryFilter{
+		FilterParams: queryParams.FilterParams,
+		ChainId:      chainId,
+		SortBy:       queryParams.SortBy,
+		SortOrder:    queryParams.SortOrder,
+		Page:         queryParams.Page,
+		Limit:        queryParams.Limit,
+	}
+
+	// Initialize the QueryResult
+	queryResult := api.QueryResponse{
+		Meta: api.Meta{
+			ChainId:    chainId.Uint64(),
+			Page:       queryParams.Page,
+			Limit:      queryParams.Limit,
+			TotalItems: 0,
+			TotalPages: 0, // TODO: Implement total pages count
+		},
+		Data:         nil,
+		Aggregations: nil,
+	}
+
+	// If aggregates or groupings are specified, retrieve them
+	if len(queryParams.Aggregates) > 0 || len(queryParams.GroupBy) > 0 {
+		qf.Aggregates = queryParams.Aggregates
+		qf.GroupBy = queryParams.GroupBy
+
+		aggregatesResult, err := mainStorage.GetAggregations("blocks", qf)
+		if err != nil {
+			log.Error().Err(err).Msg("Error querying aggregates")
+			// TODO: might want to choose BadRequestError if it's due to not-allowed functions
+			api.InternalErrorHandler(c)
+			return
+		}
+		queryResult.Aggregations = aggregatesResult.Aggregates
+		queryResult.Meta.TotalItems = len(aggregatesResult.Aggregates)
+	} else {
+		// Retrieve blocks data
+		blocksResult, err := mainStorage.GetBlocks(qf)
+		if err != nil {
+			log.Error().Err(err).Msg("Error querying blocks")
+			// TODO: might want to choose BadRequestError if it's due to not-allowed functions
+			api.InternalErrorHandler(c)
+			return
+		}
+
+		queryResult.Data = blocksResult.Data
+		queryResult.Meta.TotalItems = len(blocksResult.Data)
+	}
+
+	sendJSONResponse(c, queryResult)
+}

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -53,7 +53,7 @@ type IStagingStorage interface {
 type IMainStorage interface {
 	InsertBlockData(data *[]common.BlockData) error
 
-	GetBlocks(qf QueryFilter) (blocks []common.Block, err error)
+	GetBlocks(qf QueryFilter) (blocks QueryResult[common.Block], err error)
 	GetTransactions(qf QueryFilter) (transactions QueryResult[common.Transaction], err error)
 	GetLogs(qf QueryFilter) (logs QueryResult[common.Log], err error)
 	GetAggregations(table string, qf QueryFilter) (QueryResult[interface{}], error)

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -85,7 +85,7 @@ func (m *MemoryConnector) insertBlocks(blocks *[]common.Block) error {
 	return nil
 }
 
-func (m *MemoryConnector) GetBlocks(qf QueryFilter) ([]common.Block, error) {
+func (m *MemoryConnector) GetBlocks(qf QueryFilter) (QueryResult[common.Block], error) {
 	blocks := []common.Block{}
 	limit := getLimit(qf)
 	blockNumbersToCheck := getBlockNumbersToCheck(qf)
@@ -100,13 +100,13 @@ func (m *MemoryConnector) GetBlocks(qf QueryFilter) ([]common.Block, error) {
 				block := common.Block{}
 				err := json.Unmarshal([]byte(value), &block)
 				if err != nil {
-					return nil, err
+					return QueryResult[common.Block]{}, err
 				}
 				blocks = append(blocks, block)
 			}
 		}
 	}
-	return blocks, nil
+	return QueryResult[common.Block]{Data: blocks}, nil
 }
 
 func (m *MemoryConnector) insertTransactions(txs *[]common.Transaction) error {
@@ -120,7 +120,7 @@ func (m *MemoryConnector) insertTransactions(txs *[]common.Transaction) error {
 	return nil
 }
 
-func (m *MemoryConnector) GetTransactions(qf QueryFilter) ([]common.Transaction, error) {
+func (m *MemoryConnector) GetTransactions(qf QueryFilter) (QueryResult[common.Transaction], error) {
 	txs := []common.Transaction{}
 	limit := getLimit(qf)
 	blockNumbersToCheck := getBlockNumbersToCheck(qf)
@@ -134,13 +134,13 @@ func (m *MemoryConnector) GetTransactions(qf QueryFilter) ([]common.Transaction,
 				tx := common.Transaction{}
 				err := json.Unmarshal([]byte(value), &tx)
 				if err != nil {
-					return nil, err
+					return QueryResult[common.Transaction]{}, err
 				}
 				txs = append(txs, tx)
 			}
 		}
 	}
-	return txs, nil
+	return QueryResult[common.Transaction]{Data: txs}, nil
 }
 
 func (m *MemoryConnector) insertLogs(logs *[]common.Log) error {
@@ -154,7 +154,7 @@ func (m *MemoryConnector) insertLogs(logs *[]common.Log) error {
 	return nil
 }
 
-func (m *MemoryConnector) GetLogs(qf QueryFilter) ([]common.Log, error) {
+func (m *MemoryConnector) GetLogs(qf QueryFilter) (QueryResult[common.Log], error) {
 	logs := []common.Log{}
 	limit := getLimit(qf)
 	blockNumbersToCheck := getBlockNumbersToCheck(qf)
@@ -168,13 +168,13 @@ func (m *MemoryConnector) GetLogs(qf QueryFilter) ([]common.Log, error) {
 				log := common.Log{}
 				err := json.Unmarshal([]byte(value), &log)
 				if err != nil {
-					return nil, err
+					return QueryResult[common.Log]{}, err
 				}
 				logs = append(logs, log)
 			}
 		}
 	}
-	return logs, nil
+	return QueryResult[common.Log]{Data: logs}, nil
 }
 
 func (m *MemoryConnector) GetMaxBlockNumber(chainId *big.Int) (*big.Int, error) {
@@ -314,7 +314,7 @@ func (m *MemoryConnector) insertTraces(traces *[]common.Trace) error {
 	return nil
 }
 
-func (m *MemoryConnector) GetTraces(qf QueryFilter) ([]common.Trace, error) {
+func (m *MemoryConnector) GetTraces(qf QueryFilter) (QueryResult[common.Trace], error) {
 	traces := []common.Trace{}
 	limit := getLimit(qf)
 	blockNumbersToCheck := getBlockNumbersToCheck(qf)
@@ -328,13 +328,13 @@ func (m *MemoryConnector) GetTraces(qf QueryFilter) ([]common.Trace, error) {
 				trace := common.Trace{}
 				err := json.Unmarshal([]byte(value), &trace)
 				if err != nil {
-					return nil, err
+					return QueryResult[common.Trace]{}, err
 				}
 				traces = append(traces, trace)
 			}
 		}
 	}
-	return traces, nil
+	return QueryResult[common.Trace]{Data: traces}, nil
 }
 
 func traceAddressToString(traceAddress []uint64) string {

--- a/test/mocks/MockIMainStorage.go
+++ b/test/mocks/MockIMainStorage.go
@@ -131,24 +131,22 @@ func (_c *MockIMainStorage_GetAggregations_Call) RunAndReturn(run func(string, s
 }
 
 // GetBlocks provides a mock function with given fields: qf
-func (_m *MockIMainStorage) GetBlocks(qf storage.QueryFilter) ([]common.Block, error) {
+func (_m *MockIMainStorage) GetBlocks(qf storage.QueryFilter) (storage.QueryResult[common.Block], error) {
 	ret := _m.Called(qf)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBlocks")
 	}
 
-	var r0 []common.Block
+	var r0 storage.QueryResult[common.Block]
 	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.QueryFilter) ([]common.Block, error)); ok {
+	if rf, ok := ret.Get(0).(func(storage.QueryFilter) (storage.QueryResult[common.Block], error)); ok {
 		return rf(qf)
 	}
-	if rf, ok := ret.Get(0).(func(storage.QueryFilter) []common.Block); ok {
+	if rf, ok := ret.Get(0).(func(storage.QueryFilter) storage.QueryResult[common.Block]); ok {
 		r0 = rf(qf)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Block)
-		}
+		r0 = ret.Get(0).(storage.QueryResult[common.Block])
 	}
 
 	if rf, ok := ret.Get(1).(func(storage.QueryFilter) error); ok {
@@ -178,12 +176,12 @@ func (_c *MockIMainStorage_GetBlocks_Call) Run(run func(qf storage.QueryFilter))
 	return _c
 }
 
-func (_c *MockIMainStorage_GetBlocks_Call) Return(blocks []common.Block, err error) *MockIMainStorage_GetBlocks_Call {
+func (_c *MockIMainStorage_GetBlocks_Call) Return(blocks storage.QueryResult[common.Block], err error) *MockIMainStorage_GetBlocks_Call {
 	_c.Call.Return(blocks, err)
 	return _c
 }
 
-func (_c *MockIMainStorage_GetBlocks_Call) RunAndReturn(run func(storage.QueryFilter) ([]common.Block, error)) *MockIMainStorage_GetBlocks_Call {
+func (_c *MockIMainStorage_GetBlocks_Call) RunAndReturn(run func(storage.QueryFilter) (storage.QueryResult[common.Block], error)) *MockIMainStorage_GetBlocks_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR
Added a new `/blocks` endpoint to retrieve block data with filtering, sorting, and aggregation capabilities.

### What changed?
- Created a new `/blocks` endpoint in the API
- Implemented block data retrieval with support for:
  - Filtering by chain ID and other block parameters
  - Sorting and pagination
  - Aggregation functions
  - Group by operations
- Updated the storage interface to return QueryResult for block operations
- Added block scanning functionality to handle database rows

### How to test?
1. Start the API server
2. Make GET requests to `/blocks` with optional query parameters:
   - `chainId`: Specify the blockchain network
   - `filter`: Apply filters to block data
   - `sort_by`: Sort results by specific fields
   - `sort_order`: Choose ascending or descending order
   - `page` and `limit`: Control pagination
   - `aggregate`: Apply aggregation functions
   - `group_by`: Group results by specific fields

### Why make this change?
To provide a standardized way to query and analyze block data from the blockchain, enabling users to retrieve block information with flexible filtering and aggregation options. This enhancement aligns with the existing transaction and event query capabilities of the API.