### PR TITLE
Conform getTraces to api standard

### DIFF
--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -57,7 +57,7 @@ type IMainStorage interface {
 	GetTransactions(qf QueryFilter) (transactions QueryResult[common.Transaction], err error)
 	GetLogs(qf QueryFilter) (logs QueryResult[common.Log], err error)
 	GetAggregations(table string, qf QueryFilter) (QueryResult[interface{}], error)
-	GetTraces(qf QueryFilter) (traces []common.Trace, err error)
+	GetTraces(qf QueryFilter) (traces QueryResult[common.Trace], err error)
 	GetMaxBlockNumber(chainId *big.Int) (maxBlockNumber *big.Int, err error)
 	/**
 	 * Get block headers ordered from latest to oldest.

--- a/test/mocks/MockIMainStorage.go
+++ b/test/mocks/MockIMainStorage.go
@@ -361,24 +361,22 @@ func (_c *MockIMainStorage_GetMaxBlockNumber_Call) RunAndReturn(run func(*big.In
 }
 
 // GetTraces provides a mock function with given fields: qf
-func (_m *MockIMainStorage) GetTraces(qf storage.QueryFilter) ([]common.Trace, error) {
+func (_m *MockIMainStorage) GetTraces(qf storage.QueryFilter) (storage.QueryResult[common.Trace], error) {
 	ret := _m.Called(qf)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTraces")
 	}
 
-	var r0 []common.Trace
+	var r0 storage.QueryResult[common.Trace]
 	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.QueryFilter) ([]common.Trace, error)); ok {
+	if rf, ok := ret.Get(0).(func(storage.QueryFilter) (storage.QueryResult[common.Trace], error)); ok {
 		return rf(qf)
 	}
-	if rf, ok := ret.Get(0).(func(storage.QueryFilter) []common.Trace); ok {
+	if rf, ok := ret.Get(0).(func(storage.QueryFilter) storage.QueryResult[common.Trace]); ok {
 		r0 = rf(qf)
 	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]common.Trace)
-		}
+		r0 = ret.Get(0).(storage.QueryResult[common.Trace])
 	}
 
 	if rf, ok := ret.Get(1).(func(storage.QueryFilter) error); ok {
@@ -408,12 +406,12 @@ func (_c *MockIMainStorage_GetTraces_Call) Run(run func(qf storage.QueryFilter))
 	return _c
 }
 
-func (_c *MockIMainStorage_GetTraces_Call) Return(traces []common.Trace, err error) *MockIMainStorage_GetTraces_Call {
+func (_c *MockIMainStorage_GetTraces_Call) Return(traces storage.QueryResult[common.Trace], err error) *MockIMainStorage_GetTraces_Call {
 	_c.Call.Return(traces, err)
 	return _c
 }
 
-func (_c *MockIMainStorage_GetTraces_Call) RunAndReturn(run func(storage.QueryFilter) ([]common.Trace, error)) *MockIMainStorage_GetTraces_Call {
+func (_c *MockIMainStorage_GetTraces_Call) RunAndReturn(run func(storage.QueryFilter) (storage.QueryResult[common.Trace], error)) *MockIMainStorage_GetTraces_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR
Updated the GetTraces function to return a QueryResult type instead of a raw array of traces.

### What changed?
- Modified the GetTraces function signature to return `QueryResult[common.Trace]` instead of `[]common.Trace`
- Extracted trace scanning logic into a separate `scanTrace` function
- Updated the GetTraces implementation to use the generic `executeQuery` function
- Updated the mock storage interface to reflect the new return type

### How to test?
1. Verify that existing trace queries continue to work as expected
2. Ensure that pagination and filtering functionality works correctly with traces
3. Confirm that the mock storage interface is properly implemented in test cases

### Why make this change?
This change brings consistency to the codebase by making the GetTraces function return the same QueryResult type as other query functions. This enables better pagination support and maintains a uniform interface across all data retrieval methods.