### PR TITLE
improve token balances mv

### DIFF
--- a/internal/tools/clickhouse_create_token_balances_mv.sql
+++ b/internal/tools/clickhouse_create_token_balances_mv.sql
@@ -68,7 +68,7 @@ FROM (
                 reinterpretAsUInt64(reverse(unhex(substring(data, amounts_length_idx, 64)))) AS amounts_length,
                 amounts_length_idx + 64 as amounts_values_idx
             FROM logs
-            WHERE topic_0 = '0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb'
+            WHERE topic_0 = '0x4a39dc06d4c0dbc64b70af90fd698a233a518aa5d07e595d983b8c0526c8f7fb' AND topic_2 != '' AND topic_3 != '' AND ids_length = amounts_length
         ),
         decoded AS (
             SELECT


### PR DESCRIPTION
### TL;DR
Added validation checks for token balance materialized view to ensure data integrity.

### What changed?
Added additional WHERE clause conditions in the token balances SQL query to validate that:
- `topic_2` and `topic_3` are not empty
- `ids_length` equals `amounts_length`

### How to test?
1. Execute the materialized view creation query
2. Verify that only logs with non-empty `topic_2` and `topic_3` are processed
3. Confirm that logs where `ids_length` matches `amounts_length` are included
4. Check that malformed logs are properly filtered out

### Why make this change?
To prevent processing of invalid or malformed log entries that could lead to incorrect token balance calculations. This ensures data consistency and accuracy in the materialized view.