### PR TITLE
improve token balances endpoint performance

### DIFF
--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -31,6 +31,7 @@ type BalancesQueryFilter struct {
 	TokenAddress string
 	Owner        string
 	ZeroBalance  bool
+	GroupBy      []string
 	SortBy       string
 	SortOrder    string
 	Page         int
@@ -80,7 +81,7 @@ type IMainStorage interface {
 	GetBlockHeadersDescending(chainId *big.Int, from *big.Int, to *big.Int) (blockHeaders []common.BlockHeader, err error)
 	DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) error
 
-	GetTokenBalances(qf BalancesQueryFilter) (QueryResult[common.TokenBalance], error)
+	GetTokenBalances(qf BalancesQueryFilter, fields ...string) (QueryResult[common.TokenBalance], error)
 }
 
 func NewStorageConnector(cfg *config.StorageConfig) (IStorage, error) {

--- a/test/mocks/MockIMainStorage.go
+++ b/test/mocks/MockIMainStorage.go
@@ -390,9 +390,16 @@ func (_c *MockIMainStorage_GetMaxBlockNumber_Call) RunAndReturn(run func(*big.In
 	return _c
 }
 
-// GetTokenBalances provides a mock function with given fields: qf
-func (_m *MockIMainStorage) GetTokenBalances(qf storage.BalancesQueryFilter) (storage.QueryResult[common.TokenBalance], error) {
-	ret := _m.Called(qf)
+// GetTokenBalances provides a mock function with given fields: qf, fields
+func (_m *MockIMainStorage) GetTokenBalances(qf storage.BalancesQueryFilter, fields ...string) (storage.QueryResult[common.TokenBalance], error) {
+	_va := make([]interface{}, len(fields))
+	for _i := range fields {
+		_va[_i] = fields[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, qf)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTokenBalances")
@@ -400,17 +407,17 @@ func (_m *MockIMainStorage) GetTokenBalances(qf storage.BalancesQueryFilter) (st
 
 	var r0 storage.QueryResult[common.TokenBalance]
 	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.BalancesQueryFilter) (storage.QueryResult[common.TokenBalance], error)); ok {
-		return rf(qf)
+	if rf, ok := ret.Get(0).(func(storage.BalancesQueryFilter, ...string) (storage.QueryResult[common.TokenBalance], error)); ok {
+		return rf(qf, fields...)
 	}
-	if rf, ok := ret.Get(0).(func(storage.BalancesQueryFilter) storage.QueryResult[common.TokenBalance]); ok {
-		r0 = rf(qf)
+	if rf, ok := ret.Get(0).(func(storage.BalancesQueryFilter, ...string) storage.QueryResult[common.TokenBalance]); ok {
+		r0 = rf(qf, fields...)
 	} else {
 		r0 = ret.Get(0).(storage.QueryResult[common.TokenBalance])
 	}
 
-	if rf, ok := ret.Get(1).(func(storage.BalancesQueryFilter) error); ok {
-		r1 = rf(qf)
+	if rf, ok := ret.Get(1).(func(storage.BalancesQueryFilter, ...string) error); ok {
+		r1 = rf(qf, fields...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -425,13 +432,21 @@ type MockIMainStorage_GetTokenBalances_Call struct {
 
 // GetTokenBalances is a helper method to define mock.On call
 //   - qf storage.BalancesQueryFilter
-func (_e *MockIMainStorage_Expecter) GetTokenBalances(qf interface{}) *MockIMainStorage_GetTokenBalances_Call {
-	return &MockIMainStorage_GetTokenBalances_Call{Call: _e.mock.On("GetTokenBalances", qf)}
+//   - fields ...string
+func (_e *MockIMainStorage_Expecter) GetTokenBalances(qf interface{}, fields ...interface{}) *MockIMainStorage_GetTokenBalances_Call {
+	return &MockIMainStorage_GetTokenBalances_Call{Call: _e.mock.On("GetTokenBalances",
+		append([]interface{}{qf}, fields...)...)}
 }
 
-func (_c *MockIMainStorage_GetTokenBalances_Call) Run(run func(qf storage.BalancesQueryFilter)) *MockIMainStorage_GetTokenBalances_Call {
+func (_c *MockIMainStorage_GetTokenBalances_Call) Run(run func(qf storage.BalancesQueryFilter, fields ...string)) *MockIMainStorage_GetTokenBalances_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(storage.BalancesQueryFilter))
+		variadicArgs := make([]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(string)
+			}
+		}
+		run(args[0].(storage.BalancesQueryFilter), variadicArgs...)
 	})
 	return _c
 }
@@ -441,7 +456,7 @@ func (_c *MockIMainStorage_GetTokenBalances_Call) Return(_a0 storage.QueryResult
 	return _c
 }
 
-func (_c *MockIMainStorage_GetTokenBalances_Call) RunAndReturn(run func(storage.BalancesQueryFilter) (storage.QueryResult[common.TokenBalance], error)) *MockIMainStorage_GetTokenBalances_Call {
+func (_c *MockIMainStorage_GetTokenBalances_Call) RunAndReturn(run func(storage.BalancesQueryFilter, ...string) (storage.QueryResult[common.TokenBalance], error)) *MockIMainStorage_GetTokenBalances_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR
Added balance aggregation support for token balances API endpoint and simplified response model

### What changed?
- Modified token balance query to support aggregated balances with GROUP BY functionality
- Simplified BalanceModel response by removing redundant fields (chainId, tokenType, owner)
- Added serialization functions to transform token balances into the response model
- Updated Swagger documentation for the balance endpoint path
- Added support for custom column selection in token balance queries
- Implemented conditional balance filtering based on aggregation status

### Why make this change?
To provide more efficient token balance querying by allowing balance aggregation and reducing redundant data in the response. This improves API performance and simplifies the response structure for consumers.