### PR TITLE
move entity serialization into common package

### DIFF
--- a/internal/common/block.go
+++ b/internal/common/block.go
@@ -32,6 +32,32 @@ type Block struct {
 	InsertTimestamp  time.Time `json:"insert_timestamp" ch:"insert_timestamp"`
 }
 
+// BlockModel represents a simplified Block structure for Swagger documentation
+type BlockModel struct {
+	ChainId          string `json:"chain_id"`
+	Number           uint64 `json:"number"`
+	Hash             string `json:"hash"`
+	ParentHash       string `json:"parent_hash"`
+	Timestamp        uint64 `json:"timestamp"`
+	Nonce            string `json:"nonce"`
+	Sha3Uncles       string `json:"sha3_uncles"`
+	MixHash          string `json:"mix_hash"`
+	Miner            string `json:"miner"`
+	StateRoot        string `json:"state_root"`
+	TransactionsRoot string `json:"transactions_root"`
+	ReceiptsRoot     string `json:"receipts_root"`
+	LogsBloom        string `json:"logs_bloom"`
+	Size             uint64 `json:"size"`
+	ExtraData        string `json:"extra_data"`
+	Difficulty       string `json:"difficulty"`
+	TotalDifficulty  string `json:"total_difficulty"`
+	TransactionCount uint64 `json:"transaction_count"`
+	GasLimit         uint64 `json:"gas_limit"`
+	GasUsed          uint64 `json:"gas_used"`
+	WithdrawalsRoot  string `json:"withdrawals_root"`
+	BaseFeePerGas    uint64 `json:"base_fee_per_gas"`
+}
+
 type BlockData struct {
 	Block        Block
 	Transactions []Transaction
@@ -46,3 +72,30 @@ type BlockHeader struct {
 }
 
 type RawBlock = map[string]interface{}
+
+func (b *Block) Serialize() BlockModel {
+	return BlockModel{
+		ChainId:          b.ChainId.String(),
+		Number:           b.Number.Uint64(),
+		Hash:             b.Hash,
+		ParentHash:       b.ParentHash,
+		Timestamp:        uint64(b.Timestamp.Unix()),
+		Nonce:            b.Nonce,
+		Sha3Uncles:       b.Sha3Uncles,
+		MixHash:          b.MixHash,
+		Miner:            b.Miner,
+		StateRoot:        b.StateRoot,
+		TransactionsRoot: b.TransactionsRoot,
+		ReceiptsRoot:     b.ReceiptsRoot,
+		LogsBloom:        b.LogsBloom,
+		Size:             b.Size,
+		ExtraData:        b.ExtraData,
+		Difficulty:       b.Difficulty.String(),
+		TotalDifficulty:  b.TotalDifficulty.String(),
+		TransactionCount: b.TransactionCount,
+		GasLimit:         b.GasLimit.Uint64(),
+		GasUsed:          b.GasUsed.Uint64(),
+		WithdrawalsRoot:  b.WithdrawalsRoot,
+		BaseFeePerGas:    b.BaseFeePerGas,
+	}
+}

--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -56,6 +56,51 @@ type DecodedTransaction struct {
 	Decoded DecodedTransactionData `json:"decodedData"`
 }
 
+// TransactionModel represents a simplified Transaction structure for Swagger documentation
+type TransactionModel struct {
+	ChainId              string   `json:"chain_id"`
+	Hash                 string   `json:"hash"`
+	Nonce                uint64   `json:"nonce"`
+	BlockHash            string   `json:"block_hash"`
+	BlockNumber          uint64   `json:"block_number"`
+	BlockTimestamp       uint64   `json:"block_timestamp"`
+	TransactionIndex     uint64   `json:"transaction_index"`
+	FromAddress          string   `json:"from_address"`
+	ToAddress            string   `json:"to_address"`
+	Value                uint64   `json:"value"`
+	Gas                  uint64   `json:"gas"`
+	GasPrice             uint64   `json:"gas_price"`
+	Data                 string   `json:"data"`
+	FunctionSelector     string   `json:"function_selector"`
+	MaxFeePerGas         uint64   `json:"max_fee_per_gas"`
+	MaxPriorityFeePerGas uint64   `json:"max_priority_fee_per_gas"`
+	TransactionType      uint8    `json:"transaction_type"`
+	R                    string   `json:"r"`
+	S                    string   `json:"s"`
+	V                    string   `json:"v"`
+	AccessListJson       *string  `json:"access_list_json"`
+	ContractAddress      *string  `json:"contract_address"`
+	GasUsed              *uint64  `json:"gas_used"`
+	CumulativeGasUsed    *uint64  `json:"cumulative_gas_used"`
+	EffectiveGasPrice    *big.Int `json:"effective_gas_price"`
+	BlobGasUsed          *uint64  `json:"blob_gas_used"`
+	BlobGasPrice         *big.Int `json:"blob_gas_price"`
+	LogsBloom            *string  `json:"logs_bloom"`
+	Status               *uint64  `json:"status"`
+}
+
+type DecodedTransactionDataModel struct {
+	Name      string                 `json:"name"`
+	Signature string                 `json:"signature"`
+	Inputs    map[string]interface{} `json:"inputs"`
+}
+
+type DecodedTransactionModel struct {
+	TransactionModel
+	Decoded     DecodedTransactionDataModel `json:"decoded"`
+	DecodedData DecodedTransactionDataModel `json:"decodedData" deprecated:"true"` // Deprecated: Use Decoded field instead
+}
+
 func DecodeTransactions(chainId string, txs []Transaction) []*DecodedTransaction {
 	decodedTxs := make([]*DecodedTransaction, len(txs))
 	abiCache := make(map[string]*abi.ABI)
@@ -124,4 +169,51 @@ func (t *Transaction) Decode(functionABI *abi.Method) *DecodedTransaction {
 			Signature: functionABI.Sig,
 			Inputs:    decodedInputs,
 		}}
+}
+
+func (t *Transaction) Serialize() TransactionModel {
+	return TransactionModel{
+		ChainId:              t.ChainId.String(),
+		Hash:                 t.Hash,
+		Nonce:                t.Nonce,
+		BlockHash:            t.BlockHash,
+		BlockNumber:          t.BlockNumber.Uint64(),
+		BlockTimestamp:       uint64(t.BlockTimestamp.Unix()),
+		TransactionIndex:     t.TransactionIndex,
+		FromAddress:          t.FromAddress,
+		ToAddress:            t.ToAddress,
+		Value:                t.Value.Uint64(),
+		Gas:                  t.Gas,
+		GasPrice:             t.GasPrice.Uint64(),
+		Data:                 t.Data,
+		FunctionSelector:     t.FunctionSelector,
+		MaxFeePerGas:         t.MaxFeePerGas.Uint64(),
+		MaxPriorityFeePerGas: t.MaxPriorityFeePerGas.Uint64(),
+		TransactionType:      t.TransactionType,
+		R:                    t.R.String(),
+		S:                    t.S.String(),
+		V:                    t.V.String(),
+		AccessListJson:       t.AccessListJson,
+		ContractAddress:      t.ContractAddress,
+		GasUsed:              t.GasUsed,
+		CumulativeGasUsed:    t.CumulativeGasUsed,
+		EffectiveGasPrice:    t.EffectiveGasPrice,
+		BlobGasUsed:          t.BlobGasUsed,
+		BlobGasPrice:         t.BlobGasPrice,
+		LogsBloom:            t.LogsBloom,
+		Status:               t.Status,
+	}
+}
+
+func (t *DecodedTransaction) Serialize() DecodedTransactionModel {
+	decodedData := DecodedTransactionDataModel{
+		Name:      t.Decoded.Name,
+		Signature: t.Decoded.Signature,
+		Inputs:    t.Decoded.Inputs,
+	}
+	return DecodedTransactionModel{
+		TransactionModel: t.Transaction.Serialize(),
+		Decoded:          decodedData,
+		DecodedData:      decodedData,
+	}
 }

--- a/internal/handlers/blocks_handlers.go
+++ b/internal/handlers/blocks_handlers.go
@@ -8,32 +8,6 @@ import (
 	"github.com/thirdweb-dev/indexer/internal/storage"
 )
 
-// BlockModel represents a simplified Block structure for Swagger documentation
-type BlockModel struct {
-	ChainId          string `json:"chain_id"`
-	Number           uint64 `json:"number"`
-	Hash             string `json:"hash"`
-	ParentHash       string `json:"parent_hash"`
-	Timestamp        uint64 `json:"timestamp"`
-	Nonce            string `json:"nonce"`
-	Sha3Uncles       string `json:"sha3_uncles"`
-	MixHash          string `json:"mix_hash"`
-	Miner            string `json:"miner"`
-	StateRoot        string `json:"state_root"`
-	TransactionsRoot string `json:"transactions_root"`
-	ReceiptsRoot     string `json:"receipts_root"`
-	LogsBloom        string `json:"logs_bloom"`
-	Size             uint64 `json:"size"`
-	ExtraData        string `json:"extra_data"`
-	Difficulty       string `json:"difficulty"`
-	TotalDifficulty  string `json:"total_difficulty"`
-	TransactionCount uint64 `json:"transaction_count"`
-	GasLimit         uint64 `json:"gas_limit"`
-	GasUsed          uint64 `json:"gas_used"`
-	WithdrawalsRoot  string `json:"withdrawals_root"`
-	BaseFeePerGas    uint64 `json:"base_fee_per_gas"`
-}
-
 // @Summary Get all blocks
 // @Description Retrieve all blocks
 // @Tags blocks
@@ -49,7 +23,7 @@ type BlockModel struct {
 // @Param limit query int false "Number of items per page" default(5)
 // @Param aggregate query []string false "List of aggregate functions to apply"
 // @Param force_consistent_data query bool false "Force consistent data at the expense of query speed"
-// @Success 200 {object} api.QueryResponse{data=[]BlockModel}
+// @Success 200 {object} api.QueryResponse{data=[]common.BlockModel}
 // @Failure 400 {object} api.Error
 // @Failure 401 {object} api.Error
 // @Failure 500 {object} api.Error
@@ -133,33 +107,10 @@ func handleBlocksRequest(c *gin.Context) {
 	sendJSONResponse(c, queryResult)
 }
 
-func serializeBlocks(blocks []common.Block) []BlockModel {
-	blockModels := make([]BlockModel, len(blocks))
+func serializeBlocks(blocks []common.Block) []common.BlockModel {
+	blockModels := make([]common.BlockModel, len(blocks))
 	for i, block := range blocks {
-		blockModels[i] = BlockModel{
-			ChainId:          block.ChainId.String(),
-			Number:           block.Number.Uint64(),
-			Hash:             block.Hash,
-			ParentHash:       block.ParentHash,
-			Timestamp:        uint64(block.Timestamp.Unix()),
-			Nonce:            block.Nonce,
-			Sha3Uncles:       block.Sha3Uncles,
-			MixHash:          block.MixHash,
-			Miner:            block.Miner,
-			StateRoot:        block.StateRoot,
-			TransactionsRoot: block.TransactionsRoot,
-			ReceiptsRoot:     block.ReceiptsRoot,
-			LogsBloom:        block.LogsBloom,
-			Size:             block.Size,
-			ExtraData:        block.ExtraData,
-			Difficulty:       block.Difficulty.String(),
-			TotalDifficulty:  block.TotalDifficulty.String(),
-			TransactionCount: block.TransactionCount,
-			GasLimit:         block.GasLimit.Uint64(),
-			GasUsed:          block.GasUsed.Uint64(),
-			WithdrawalsRoot:  block.WithdrawalsRoot,
-			BaseFeePerGas:    block.BaseFeePerGas,
-		}
+		blockModels[i] = block.Serialize()
 	}
 	return blockModels
 }


### PR DESCRIPTION
Creates a `Serialize` function for each entity in the common package which makes it easier to reuse in other endpoints