### PR TITLE
search endpoint

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -89,6 +89,9 @@ func RunApi(cmd *cobra.Command, args []string) {
 
 		// token holder queries
 		root.GET("/holders/:address", handlers.GetTokenHoldersByType)
+
+		// search
+		root.GET("/search/:input", handlers.Search)
 	}
 
 	r.GET("/health", func(c *gin.Context) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -100,6 +100,7 @@ func init() {
 	rootCmd.PersistentFlags().String("api-host", "localhost:3000", "API host")
 	rootCmd.PersistentFlags().String("api-basicAuth-username", "", "API basic auth username")
 	rootCmd.PersistentFlags().String("api-basicAuth-password", "", "API basic auth password")
+	rootCmd.PersistentFlags().String("api-thirdweb-clientId", "", "Thirdweb client id")
 	viper.BindPFlag("rpc.url", rootCmd.PersistentFlags().Lookup("rpc-url"))
 	viper.BindPFlag("rpc.blocks.blocksPerRequest", rootCmd.PersistentFlags().Lookup("rpc-blocks-blocksPerRequest"))
 	viper.BindPFlag("rpc.blocks.batchDelay", rootCmd.PersistentFlags().Lookup("rpc-blocks-batchDelay"))
@@ -164,6 +165,7 @@ func init() {
 	viper.BindPFlag("api.host", rootCmd.PersistentFlags().Lookup("api-host"))
 	viper.BindPFlag("api.basicAuth.username", rootCmd.PersistentFlags().Lookup("api-basicAuth-username"))
 	viper.BindPFlag("api.basicAuth.password", rootCmd.PersistentFlags().Lookup("api-basicAuth-password"))
+	viper.BindPFlag("api.thirdweb.clientId", rootCmd.PersistentFlags().Lookup("api-thirdweb-clientId"))
 	rootCmd.AddCommand(orchestratorCmd)
 	rootCmd.AddCommand(apiCmd)
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -118,11 +118,16 @@ type BasicAuthConfig struct {
 	Password string `mapstructure:"password"`
 }
 
+type ThirdwebConfig struct {
+	ClientId string `mapstructure:"clientId"`
+}
+
 type APIConfig struct {
 	Host                string          `mapstructure:"host"`
 	BasicAuth           BasicAuthConfig `mapstructure:"basicAuth"`
 	ThirdwebContractApi string          `mapstructure:"thirdwebContractApi"`
 	AbiDecodingEnabled  bool            `mapstructure:"abiDecodingEnabled"`
+	Thirdweb            ThirdwebConfig  `mapstructure:"thirdweb"`
 }
 
 type Config struct {

--- a/configs/secrets.example.yml
+++ b/configs/secrets.example.yml
@@ -5,6 +5,8 @@ api:
   basicAuth:
     username: admin
     password: admin
+  thirdweb:
+    clientId: 123abc
 
 storage:
   main:

--- a/internal/handlers/search_handlers.go
+++ b/internal/handlers/search_handlers.go
@@ -1,0 +1,391 @@
+package handlers
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rs/zerolog/log"
+	"github.com/thirdweb-dev/indexer/api"
+	config "github.com/thirdweb-dev/indexer/configs"
+	"github.com/thirdweb-dev/indexer/internal/common"
+	"github.com/thirdweb-dev/indexer/internal/rpc"
+	"github.com/thirdweb-dev/indexer/internal/storage"
+)
+
+type SearchResultType string
+
+const (
+	SearchResultTypeBlock             SearchResultType = "block"
+	SearchResultTypeTransaction       SearchResultType = "transaction"
+	SearchResultTypeEventSignature    SearchResultType = "event_signature"
+	SearchResultTypeFunctionSignature SearchResultType = "function_signature"
+	SearchResultTypeAddress           SearchResultType = "address"
+	SearchResultTypeContract          SearchResultType = "contract"
+)
+
+type SearchResultModel struct {
+	Blocks       []common.BlockModel       `json:"blocks,omitempty"`
+	Transactions []common.TransactionModel `json:"transactions,omitempty"`
+	Events       []common.LogModel         `json:"events,omitempty"`
+	Type         SearchResultType          `json:"type,omitempty"`
+}
+
+type SearchInput struct {
+	BlockNumber       *big.Int
+	Hash              string
+	Address           string
+	FunctionSignature string
+	ErrorMessage      string
+}
+
+// @Summary Search blockchain data
+// @Description Search blocks, transactions and events
+// @Tags search
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param chainId path string true "Chain ID"
+// @Param input path string true "Search input"
+// @Success 200 {object} api.QueryResponse{data=SearchResultModel}
+// @Failure 400 {object} api.Error
+// @Failure 401 {object} api.Error
+// @Failure 500 {object} api.Error
+// @Router /search/:input [GET]
+func Search(c *gin.Context) {
+	chainId, err := api.GetChainId(c)
+	if err != nil {
+		api.BadRequestErrorHandler(c, err)
+		return
+	}
+	searchInput := parseSearchInput(c.Param("input"))
+	if searchInput.ErrorMessage != "" {
+		api.BadRequestErrorHandler(c, fmt.Errorf(searchInput.ErrorMessage))
+		return
+	}
+
+	mainStorage, err := getMainStorage()
+	if err != nil {
+		log.Error().Err(err).Msg("Error getting main storage")
+		api.InternalErrorHandler(c)
+		return
+	}
+
+	result, err := executeSearch(mainStorage, chainId, searchInput)
+	if err != nil {
+		log.Error().Err(err).Msg("Error executing search")
+		api.InternalErrorHandler(c)
+		return
+	}
+
+	sendJSONResponse(c, api.QueryResponse{
+		Meta: api.Meta{
+			ChainId: chainId.Uint64(),
+		},
+		Data: result,
+	})
+}
+
+func parseSearchInput(searchInput string) SearchInput {
+	if searchInput == "" {
+		return SearchInput{ErrorMessage: "search input cannot be empty"}
+	}
+
+	blockNumber, ok := new(big.Int).SetString(searchInput, 10)
+	if ok {
+		if blockNumber.Sign() == -1 {
+			return SearchInput{ErrorMessage: fmt.Sprintf("invalid block number '%s'", searchInput)}
+		}
+		return SearchInput{BlockNumber: blockNumber}
+	}
+
+	if isValidHashWithLength(searchInput, 66) {
+		return SearchInput{Hash: searchInput}
+	} else if isValidHashWithLength(searchInput, 42) {
+		return SearchInput{Address: searchInput}
+	} else if isValidHashWithLength(searchInput, 10) {
+		return SearchInput{FunctionSignature: searchInput}
+	}
+	return SearchInput{ErrorMessage: fmt.Sprintf("invalid input '%s'", searchInput)}
+}
+
+func isValidHashWithLength(input string, length int) bool {
+	if len(input) == length && strings.HasPrefix(input, "0x") {
+		_, err := hex.DecodeString(input[2:])
+		if err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func executeSearch(storage storage.IMainStorage, chainId *big.Int, input SearchInput) (SearchResultModel, error) {
+	switch {
+	case input.BlockNumber != nil:
+		block, err := searchByBlockNumber(storage, chainId, input.BlockNumber)
+		return SearchResultModel{Blocks: []common.BlockModel{*block}, Type: SearchResultTypeBlock}, err
+
+	case input.Hash != "":
+		return searchByHash(storage, chainId, input.Hash)
+
+	case input.Address != "":
+		return searchByAddress(storage, chainId, input.Address)
+
+	case input.FunctionSignature != "":
+		transactions, err := searchByFunctionSelector(storage, chainId, input.FunctionSignature)
+		return SearchResultModel{Transactions: transactions, Type: SearchResultTypeFunctionSignature}, err
+
+	default:
+		return SearchResultModel{}, nil
+	}
+}
+
+func searchByBlockNumber(mainStorage storage.IMainStorage, chainId *big.Int, blockNumber *big.Int) (*common.BlockModel, error) {
+	result, err := mainStorage.GetBlocks(storage.QueryFilter{
+		ChainId:      chainId,
+		BlockNumbers: []*big.Int{blockNumber},
+		Limit:        1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	blocks := result.Data
+	if len(blocks) == 0 {
+		return nil, nil
+	}
+	block := blocks[0].Serialize()
+	return &block, nil
+}
+
+func searchByFunctionSelector(mainStorage storage.IMainStorage, chainId *big.Int, functionSelector string) ([]common.TransactionModel, error) {
+	result, err := mainStorage.GetTransactions(storage.QueryFilter{
+		ChainId:   chainId,
+		Signature: functionSelector,
+		SortBy:    "block_number",
+		SortOrder: "desc",
+		Limit:     20,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(result.Data) == 0 {
+		return []common.TransactionModel{}, nil
+	}
+
+	transactions := make([]common.TransactionModel, len(result.Data))
+	for i, transaction := range result.Data {
+		transactions[i] = transaction.Serialize()
+	}
+	return transactions, nil
+}
+
+func searchByHash(mainStorage storage.IMainStorage, chainId *big.Int, hash string) (SearchResultModel, error) {
+	var result SearchResultModel
+	var wg sync.WaitGroup
+	resultChan := make(chan SearchResultModel)
+	doneChan := make(chan struct{})
+	errChan := make(chan error)
+
+	// Try as transaction hash
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		txResult, err := mainStorage.GetTransactions(storage.QueryFilter{
+			ChainId: chainId,
+			FilterParams: map[string]string{
+				"hash": hash,
+			},
+			Limit: 1,
+		})
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if len(txResult.Data) > 0 {
+			txModel := txResult.Data[0].Serialize()
+			select {
+			case resultChan <- SearchResultModel{Transactions: []common.TransactionModel{txModel}, Type: SearchResultTypeTransaction}:
+			case <-doneChan:
+			}
+		}
+	}()
+
+	// Try as block hash
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		blockResult, err := mainStorage.GetBlocks(storage.QueryFilter{
+			ChainId: chainId,
+			FilterParams: map[string]string{
+				"hash": hash,
+			},
+			Limit: 1,
+		})
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if len(blockResult.Data) > 0 {
+			blockModel := blockResult.Data[0].Serialize()
+			select {
+			case resultChan <- SearchResultModel{Blocks: []common.BlockModel{blockModel}, Type: SearchResultTypeBlock}:
+			case <-doneChan:
+			}
+		}
+	}()
+
+	// Try as topic_0 for logs
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		logsResult, err := mainStorage.GetLogs(storage.QueryFilter{
+			ChainId:   chainId,
+			Signature: hash,
+			Limit:     20,
+			SortBy:    "block_number",
+			SortOrder: "desc",
+		})
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if len(logsResult.Data) > 0 {
+			logs := make([]common.LogModel, len(logsResult.Data))
+			for i, log := range logsResult.Data {
+				logs[i] = log.Serialize()
+			}
+			select {
+			case resultChan <- SearchResultModel{Events: logs, Type: SearchResultTypeEventSignature}:
+			case <-doneChan:
+			}
+		}
+	}()
+
+	// Wait for first result or all goroutines to finish
+	go func() {
+		wg.Wait()
+		close(resultChan)
+	}()
+
+	// Get first result or error
+	select {
+	case err := <-errChan:
+		close(doneChan)
+		return result, err
+	case res, ok := <-resultChan:
+		if !ok {
+			return result, nil // No results found
+		}
+		close(doneChan)
+		return res, nil
+	}
+}
+
+func searchByAddress(mainStorage storage.IMainStorage, chainId *big.Int, address string) (SearchResultModel, error) {
+	searchResult := SearchResultModel{Type: SearchResultTypeAddress}
+	contractCode, err := checkIfContractHasCode(chainId, address)
+	if err != nil {
+		return searchResult, err
+	}
+	if contractCode == ContractCodeExists {
+		searchResult.Type = SearchResultTypeContract
+		txs, err := findLatestTransactionsToAddress(mainStorage, chainId, address)
+		if err == nil {
+			searchResult.Transactions = txs
+			return searchResult, nil
+		}
+		return searchResult, err
+	} else if contractCode == ContractCodeDoesNotExist {
+		txs, err := findLatestTransactionsFromAddress(mainStorage, chainId, address)
+		if err == nil {
+			searchResult.Transactions = txs
+			return searchResult, nil
+		}
+		return searchResult, err
+	} else {
+		transactionsTo, err := findLatestTransactionsToAddress(mainStorage, chainId, address)
+		if err != nil {
+			return searchResult, err
+		}
+		for _, tx := range transactionsTo {
+			if len(tx.Data) > 0 && tx.Data != "0x" {
+				// if any received transactions is a function call, likely a contract
+				searchResult.Type = SearchResultTypeContract
+				searchResult.Transactions = transactionsTo
+				return searchResult, nil
+			}
+		}
+		transactionsFrom, err := findLatestTransactionsFromAddress(mainStorage, chainId, address)
+		if err != nil {
+			return searchResult, err
+		}
+		searchResult.Transactions = transactionsFrom
+		return searchResult, nil
+	}
+}
+
+func findLatestTransactionsToAddress(mainStorage storage.IMainStorage, chainId *big.Int, address string) ([]common.TransactionModel, error) {
+	result, err := mainStorage.GetTransactions(storage.QueryFilter{
+		ChainId:         chainId,
+		ContractAddress: address,
+		Limit:           20,
+		SortBy:          "block_number",
+		SortOrder:       "desc",
+	})
+	if err != nil {
+		return nil, err
+	}
+	transactions := make([]common.TransactionModel, len(result.Data))
+	for i, transaction := range result.Data {
+		transactions[i] = transaction.Serialize()
+	}
+	return transactions, nil
+}
+
+func findLatestTransactionsFromAddress(mainStorage storage.IMainStorage, chainId *big.Int, address string) ([]common.TransactionModel, error) {
+	result, err := mainStorage.GetTransactions(storage.QueryFilter{
+		ChainId:     chainId,
+		FromAddress: address,
+		Limit:       20,
+		SortBy:      "block_number",
+		SortOrder:   "desc",
+	})
+	if err != nil {
+		return nil, err
+	}
+	transactions := make([]common.TransactionModel, len(result.Data))
+	for i, transaction := range result.Data {
+		transactions[i] = transaction.Serialize()
+	}
+	return transactions, nil
+}
+
+type ContractCodeState int
+
+const (
+	ContractCodeUnknown ContractCodeState = iota
+	ContractCodeExists
+	ContractCodeDoesNotExist
+)
+
+func checkIfContractHasCode(chainId *big.Int, address string) (ContractCodeState, error) {
+	if config.Cfg.API.Thirdweb.ClientId != "" {
+		rpcUrl := fmt.Sprintf("https://%s.rpc.thirdweb.com/%s", chainId.String(), config.Cfg.API.Thirdweb.ClientId)
+		r, err := rpc.InitializeSimpleRPCWithUrl(rpcUrl)
+		if err != nil {
+			return ContractCodeUnknown, err
+		}
+		hasCode, err := r.HasCode(address)
+		if err != nil {
+			return ContractCodeUnknown, err
+		}
+		if hasCode {
+			return ContractCodeExists, nil
+		}
+		return ContractCodeDoesNotExist, nil
+	}
+	return ContractCodeUnknown, nil
+}

--- a/internal/handlers/search_handlers_test.go
+++ b/internal/handlers/search_handlers_test.go
@@ -1,0 +1,274 @@
+package handlers
+
+import (
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/thirdweb-dev/indexer/internal/common"
+	"github.com/thirdweb-dev/indexer/internal/storage"
+	"github.com/thirdweb-dev/indexer/test/mocks"
+)
+
+func setupTestRouter() (*gin.Engine, *mocks.MockIMainStorage) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	mockStorage := new(mocks.MockIMainStorage)
+
+	// Set the mock storage as the global storage
+	mainStorage = mockStorage
+	storageOnce.Do(func() {
+		mainStorage = mockStorage
+	})
+	storageErr = nil
+
+	router.GET("/v1/search/:chainId/:input", Search)
+	return router, mockStorage
+}
+
+func TestSearch_BlockNumber(t *testing.T) {
+	router, mockStorage := setupTestRouter()
+
+	blockNumber := big.NewInt(12345)
+	mockStorage.EXPECT().GetBlocks(mock.Anything).Return(storage.QueryResult[common.Block]{
+		Data: []common.Block{{
+			Number:   blockNumber,
+			Hash:     "0xabc",
+			GasLimit: big.NewInt(1000000),
+			GasUsed:  big.NewInt(500000),
+		}},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/search/1/12345", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	var response struct {
+		Data struct {
+			Blocks []common.BlockModel `json:"blocks"`
+			Type   SearchResultType    `json:"type"`
+		} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, SearchResultTypeBlock, response.Data.Type)
+	assert.Equal(t, blockNumber.Uint64(), response.Data.Blocks[0].Number)
+	assert.Equal(t, "0xabc", response.Data.Blocks[0].Hash)
+
+	mockStorage.AssertExpectations(t)
+}
+
+func TestSearch_TransactionHash(t *testing.T) {
+	router, mockStorage := setupTestRouter()
+
+	txHash := "0x1234567890123456789012345678901234567890123456789012345678901234"
+
+	mockStorage.EXPECT().GetTransactions(mock.MatchedBy(func(filter storage.QueryFilter) bool {
+		return filter.ChainId.Cmp(big.NewInt(1)) == 0 &&
+			filter.FilterParams["hash"] == txHash
+	})).Return(storage.QueryResult[common.Transaction]{
+		Data: []common.Transaction{{
+			Hash:                 txHash,
+			BlockNumber:          big.NewInt(12345),
+			Value:                big.NewInt(0),
+			GasPrice:             big.NewInt(500000),
+			MaxFeePerGas:         big.NewInt(500000),
+			MaxPriorityFeePerGas: big.NewInt(500000),
+		}},
+	}, nil)
+
+	// Mock other necessary calls for block and logs search
+	mockStorage.EXPECT().GetBlocks(mock.Anything).Return(storage.QueryResult[common.Block]{}, nil)
+	mockStorage.EXPECT().GetLogs(mock.Anything).Return(storage.QueryResult[common.Log]{}, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/search/1/"+txHash, nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	var response struct {
+		Data struct {
+			Transactions []common.TransactionModel `json:"transactions"`
+			Type         SearchResultType          `json:"type"`
+		} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, SearchResultTypeTransaction, response.Data.Type)
+	assert.Equal(t, txHash, response.Data.Transactions[0].Hash)
+
+	mockStorage.AssertExpectations(t)
+}
+
+func TestSearch_Address(t *testing.T) {
+	router, mockStorage := setupTestRouter()
+
+	address := "0x1234567890123456789012345678901234567890"
+	mockStorage.On("GetTransactions", mock.MatchedBy(func(filter storage.QueryFilter) bool {
+		return filter.ChainId.Cmp(big.NewInt(1)) == 0 &&
+			filter.ContractAddress == address
+	})).Return(storage.QueryResult[common.Transaction]{
+		Data: []common.Transaction{{
+			ToAddress:            address,
+			BlockNumber:          big.NewInt(12345),
+			Value:                big.NewInt(0),
+			GasPrice:             big.NewInt(500000),
+			MaxFeePerGas:         big.NewInt(500000),
+			MaxPriorityFeePerGas: big.NewInt(500000),
+		}},
+	}, nil)
+
+	mockStorage.On("GetTransactions", mock.MatchedBy(func(filter storage.QueryFilter) bool {
+		return filter.ChainId.Cmp(big.NewInt(1)) == 0 &&
+			filter.FromAddress == address
+	})).Return(storage.QueryResult[common.Transaction]{
+		Data: []common.Transaction{{
+			FromAddress:          address,
+			BlockNumber:          big.NewInt(12345),
+			Value:                big.NewInt(0),
+			GasPrice:             big.NewInt(500000),
+			MaxFeePerGas:         big.NewInt(500000),
+			MaxPriorityFeePerGas: big.NewInt(500000),
+		}},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/search/1/"+address, nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	var response struct {
+		Data struct {
+			Transactions []common.TransactionModel `json:"transactions"`
+			Type         SearchResultType          `json:"type"`
+		} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, SearchResultTypeAddress, response.Data.Type)
+	assert.Equal(t, address, response.Data.Transactions[0].FromAddress)
+
+	mockStorage.AssertExpectations(t)
+}
+
+func TestSearch_Contract(t *testing.T) {
+	router, mockStorage := setupTestRouter()
+
+	address := "0x1234567890123456789012345678901234567890"
+	mockStorage.On("GetTransactions", mock.MatchedBy(func(filter storage.QueryFilter) bool {
+		return filter.ChainId.Cmp(big.NewInt(1)) == 0 &&
+			filter.ContractAddress == address
+	})).Return(storage.QueryResult[common.Transaction]{
+		Data: []common.Transaction{{
+			ToAddress:            address,
+			BlockNumber:          big.NewInt(12345),
+			Value:                big.NewInt(0),
+			GasPrice:             big.NewInt(500000),
+			MaxFeePerGas:         big.NewInt(500000),
+			MaxPriorityFeePerGas: big.NewInt(500000),
+			Data:                 "0xaabbccdd",
+		}},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/search/1/"+address, nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	var response struct {
+		Data struct {
+			Transactions []common.TransactionModel `json:"transactions"`
+			Type         SearchResultType          `json:"type"`
+		} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, SearchResultTypeContract, response.Data.Type)
+	assert.Equal(t, address, response.Data.Transactions[0].ToAddress)
+	assert.Equal(t, "0xaabbccdd", response.Data.Transactions[0].Data)
+
+	mockStorage.AssertExpectations(t)
+}
+
+func TestSearch_FunctionSignature(t *testing.T) {
+	router, mockStorage := setupTestRouter()
+
+	signature := "0x12345678"
+	mockStorage.On("GetTransactions", mock.MatchedBy(func(filter storage.QueryFilter) bool {
+		return filter.ChainId.Cmp(big.NewInt(1)) == 0 &&
+			filter.Signature == signature
+	})).Return(storage.QueryResult[common.Transaction]{
+		Data: []common.Transaction{{
+			Data:                 signature + "000000",
+			BlockNumber:          big.NewInt(12345),
+			Value:                big.NewInt(0),
+			GasPrice:             big.NewInt(500000),
+			MaxFeePerGas:         big.NewInt(500000),
+			MaxPriorityFeePerGas: big.NewInt(500000),
+		}},
+	}, nil)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/search/1/"+signature, nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 200, w.Code)
+
+	var response struct {
+		Data struct {
+			Transactions []common.TransactionModel `json:"transactions"`
+			Type         SearchResultType          `json:"type"`
+		} `json:"data"`
+	}
+	err := json.Unmarshal(w.Body.Bytes(), &response)
+	assert.NoError(t, err)
+	assert.Equal(t, SearchResultTypeFunctionSignature, response.Data.Type)
+	assert.Equal(t, signature+"000000", response.Data.Transactions[0].Data)
+
+	mockStorage.AssertExpectations(t)
+}
+
+func TestSearch_InvalidInput(t *testing.T) {
+	router, _ := setupTestRouter()
+
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{"Empty input", " "},
+		{"Invalid block number", "-1"},
+		{"Invalid hash", "0xinvalidhash"},
+		{"Invalid address", "0xinvalidaddress"},
+		{"Invalid function signature", "0xinvalidsig"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequest("GET", "/v1/search/1/"+tc.input, nil)
+			router.ServeHTTP(w, req)
+
+			assert.Equal(t, 400, w.Code)
+		})
+	}
+}
+
+func TestSearch_InvalidChainId(t *testing.T) {
+	router, _ := setupTestRouter()
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/v1/search/invalid/12345", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 400, w.Code)
+}

--- a/test/mocks/MockIRPCClient.go
+++ b/test/mocks/MockIRPCClient.go
@@ -314,6 +314,62 @@ func (_c *MockIRPCClient_GetURL_Call) RunAndReturn(run func() string) *MockIRPCC
 	return _c
 }
 
+// HasCode provides a mock function with given fields: address
+func (_m *MockIRPCClient) HasCode(address string) (bool, error) {
+	ret := _m.Called(address)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasCode")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return rf(address)
+	}
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(address)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(address)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockIRPCClient_HasCode_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasCode'
+type MockIRPCClient_HasCode_Call struct {
+	*mock.Call
+}
+
+// HasCode is a helper method to define mock.On call
+//   - address string
+func (_e *MockIRPCClient_Expecter) HasCode(address interface{}) *MockIRPCClient_HasCode_Call {
+	return &MockIRPCClient_HasCode_Call{Call: _e.mock.On("HasCode", address)}
+}
+
+func (_c *MockIRPCClient_HasCode_Call) Run(run func(address string)) *MockIRPCClient_HasCode_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockIRPCClient_HasCode_Call) Return(_a0 bool, _a1 error) *MockIRPCClient_HasCode_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockIRPCClient_HasCode_Call) RunAndReturn(run func(string) (bool, error)) *MockIRPCClient_HasCode_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsWebsocket provides a mock function with no fields
 func (_m *MockIRPCClient) IsWebsocket() bool {
 	ret := _m.Called()


### PR DESCRIPTION
Implements a search endpoint
* For a numeric value, tries to fetch a block
* For a hash value (length 66 with 0x) tries to fetch a block, a transaction and logs by signature. Whichever returns data first will be returned
* For a hash value (length 10) fetches transactions with that function selector
* For addresses, uses RPC to check for code. If not configured, looks at latest transactions and determines if it's a contract or not. 
For EOAs returns last 20 initiated transactions
For contracts returns last 20 received transactions
