### PR TITLE
rename block fields in api

### DIFF
--- a/internal/common/block.go
+++ b/internal/common/block.go
@@ -35,10 +35,10 @@ type Block struct {
 // BlockModel represents a simplified Block structure for Swagger documentation
 type BlockModel struct {
 	ChainId          string `json:"chain_id"`
-	Number           uint64 `json:"number"`
-	Hash             string `json:"hash"`
+	BlockNumber      uint64 `json:"block_number"`
+	BlockHash        string `json:"block_hash"`
 	ParentHash       string `json:"parent_hash"`
-	Timestamp        uint64 `json:"timestamp"`
+	BlockTimestamp   uint64 `json:"block_timestamp"`
 	Nonce            string `json:"nonce"`
 	Sha3Uncles       string `json:"sha3_uncles"`
 	MixHash          string `json:"mix_hash"`
@@ -76,10 +76,10 @@ type RawBlock = map[string]interface{}
 func (b *Block) Serialize() BlockModel {
 	return BlockModel{
 		ChainId:          b.ChainId.String(),
-		Number:           b.Number.Uint64(),
-		Hash:             b.Hash,
+		BlockNumber:      b.Number.Uint64(),
+		BlockHash:        b.Hash,
 		ParentHash:       b.ParentHash,
-		Timestamp:        uint64(b.Timestamp.Unix()),
+		BlockTimestamp:   uint64(b.Timestamp.Unix()),
 		Nonce:            b.Nonce,
 		Sha3Uncles:       b.Sha3Uncles,
 		MixHash:          b.MixHash,

--- a/internal/handlers/search_handlers_test.go
+++ b/internal/handlers/search_handlers_test.go
@@ -59,8 +59,8 @@ func TestSearch_BlockNumber(t *testing.T) {
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, SearchResultTypeBlock, response.Data.Type)
-	assert.Equal(t, blockNumber.Uint64(), response.Data.Blocks[0].Number)
-	assert.Equal(t, "0xabc", response.Data.Blocks[0].Hash)
+	assert.Equal(t, blockNumber.Uint64(), response.Data.Blocks[0].BlockNumber)
+	assert.Equal(t, "0xabc", response.Data.Blocks[0].BlockHash)
 
 	mockStorage.AssertExpectations(t)
 }


### PR DESCRIPTION
Renames `hash` -> `block_hash`, `number` -> `block_number` and `timestamp` -> `block_timestamp` for the block API to have a more uniform naming schema