### PR TITLE
fix erc1155 single transfers materialized view

### DIFF
--- a/internal/tools/clickhouse_create_token_balances_mv.sql
+++ b/internal/tools/clickhouse_create_token_balances_mv.sql
@@ -20,8 +20,8 @@ FROM
         (topic_0 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' AND topic_3 = '') as is_erc20,
         (topic_0 = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef' AND topic_3 != '') as is_erc721,
         (topic_0 = '0xc3d58168c5ae7397731d063d5bbf3d657854427343f4c083240f7aacaa2d0f62') as is_erc1155,
-        if(is_erc1155, concat('0x', substring(topic_2, 27, 40)), concat('0x', substring(topic_1, 27, 40))) AS sender_address,
-        if(is_erc1155, concat('0x', substring(topic_3, 27, 40)), concat('0x', substring(topic_2, 27, 40))) AS receiver_address,
+        if(is_erc1155, concat('0x', substring(topic_2, 27, 40)), concat('0x', substring(topic_1, 27, 40))) AS sender_address, -- ERC20 & ERC721 both have topic_1 as sender
+        if(is_erc1155, concat('0x', substring(topic_3, 27, 40)), concat('0x', substring(topic_2, 27, 40))) AS receiver_address, -- ERC20 & ERC721 both have topic_2 as receiver
         multiIf(is_erc20, 'erc20', is_erc721, 'erc721', 'erc1155') as token_type,
         multiIf(
             is_erc1155,
@@ -33,10 +33,12 @@ FROM
         multiIf(
             is_erc20 AND length(data) = 66,
             reinterpretAsInt256(reverse(unhex(substring(data, 3)))),
-            is_erc721 OR is_erc1155,
+            is_erc721, 
             toInt256(1),
+            is_erc1155,
+            if(length(data) = 130, reinterpretAsInt256(reverse(unhex(substring(data, 67, 64)))), toInt256(1)),
             toInt256(0) -- unknown
-        ) as transfer_amount,
+        ) AS transfer_amount,
         (sign * transfer_amount) as amount
     FROM logs
     WHERE


### PR DESCRIPTION
### TL;DR
Added support for ERC1155 token amount parsing in token balance materialized view

### What changed?
Updated the token balance calculation logic to properly handle ERC1155 token amounts by parsing the data field when it contains batch transfer information (130 characters). For ERC1155 transfers, it now extracts the amount from the appropriate position in the data field, defaulting to 1 if not present.

### Why make this change?
ERC1155 tokens can transfer multiple tokens in a single transaction. The previous implementation treated all ERC1155 transfers as single unit transfers, which was incorrect for batch transfers. This change ensures accurate token balance tracking for ERC1155 tokens.