### PR TITLE
feat: include token type to response

### DIFF
--- a/internal/handlers/token_handlers.go
+++ b/internal/handlers/token_handlers.go
@@ -17,12 +17,14 @@ type BalanceModel struct {
 	TokenAddress string `json:"token_address" ch:"address"`
 	TokenId      string `json:"token_id" ch:"token_id"`
 	Balance      string `json:"balance" ch:"balance"`
+	TokenType    string `json:"token_type" ch:"token_type"`
 }
 
 type HolderModel struct {
 	HolderAddress string `json:"holder_address" ch:"owner"`
 	TokenId       string `json:"token_id" ch:"token_id"`
 	Balance       string `json:"balance" ch:"balance"`
+	TokenType     string `json:"token_type" ch:"token_type"`
 }
 
 // @Summary Get token balances of an address by type
@@ -77,8 +79,8 @@ func GetTokenBalancesByType(c *gin.Context) {
 	columns := []string{"address", "sum(balance) as balance"}
 	groupBy := []string{"address"}
 	if !strings.Contains(strings.Join(tokenTypes, ","), "erc20") {
-		columns = []string{"address", "token_id", "sum(balance) as balance"}
-		groupBy = []string{"address", "token_id"}
+		columns = []string{"address", "token_id", "sum(balance) as balance", "token_type"}
+		groupBy = []string{"address", "token_id", "token_type"}
 	}
 
 	qf := storage.BalancesQueryFilter{
@@ -139,6 +141,7 @@ func serializeBalance(balance common.TokenBalance) BalanceModel {
 			}
 			return ""
 		}(),
+		TokenType: balance.TokenType,
 	}
 }
 
@@ -220,8 +223,8 @@ func GetTokenHoldersByType(c *gin.Context) {
 	groupBy := []string{"owner"}
 
 	if !strings.Contains(strings.Join(tokenTypes, ","), "erc20") {
-		columns = []string{"owner", "token_id", "sum(balance) as balance"}
-		groupBy = []string{"owner", "token_id"}
+		columns = []string{"owner", "token_id", "sum(balance) as balance", "token_type"}
+		groupBy = []string{"owner", "token_id", "token_type"}
 	}
 
 	tokenIds, err := getTokenIdsFromReq(c)
@@ -286,5 +289,6 @@ func serializeHolder(holder common.TokenBalance) HolderModel {
 			}
 			return ""
 		}(),
+		TokenType: holder.TokenType,
 	}
 }


### PR DESCRIPTION
### TL;DR

Added `token_type` field to the `HolderModel` struct and included it in the serialization function.

We need it to properly detect token types for NFTs handlers, specifically for further metadata resolutions.

### What changed?

- Added a new `TokenType` field to the `HolderModel` struct with JSON tag `token_type` and ClickHouse tag `token_type`
- Updated the `serializeHolder` function to populate the new `TokenType` field from the `holder.TokenType` value

### How to test?

1. Make a request to an endpoint that returns token holder data
2. Verify that the response now includes the `token_type` field in the JSON output
3. Check that the value matches the expected token type for the given token

### Why make this change?

This change enhances the token holder API response by including the token type information, which allows clients to distinguish between different token standards (e.g., ERC-20, ERC-721, ERC-1155) without having to make additional queries. This provides more complete information about tokens in a single response.