### PR TITLE
do not pass around pointers to slices and maps

### DIFF
--- a/internal/orchestrator/committer_test.go
+++ b/internal/orchestrator/committer_test.go
@@ -252,13 +252,13 @@ func TestGetSequentialBlockDataToCommit(t *testing.T) {
 	mockStagingStorage.EXPECT().GetStagingData(storage.QueryFilter{
 		ChainId:      chainID,
 		BlockNumbers: []*big.Int{big.NewInt(101), big.NewInt(102), big.NewInt(103)},
-	}).Return(&blockData, nil)
+	}).Return(blockData, nil)
 
 	result, err := committer.getSequentialBlockDataToCommit()
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, 3, len(*result))
+	assert.Equal(t, 3, len(result))
 }
 
 func TestGetSequentialBlockDataToCommitWithDuplicateBlocks(t *testing.T) {
@@ -288,16 +288,16 @@ func TestGetSequentialBlockDataToCommitWithDuplicateBlocks(t *testing.T) {
 	mockStagingStorage.EXPECT().GetStagingData(storage.QueryFilter{
 		ChainId:      chainID,
 		BlockNumbers: []*big.Int{big.NewInt(101), big.NewInt(102), big.NewInt(103)},
-	}).Return(&blockData, nil)
+	}).Return(blockData, nil)
 
 	result, err := committer.getSequentialBlockDataToCommit()
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
-	assert.Equal(t, 3, len(*result))
-	assert.Equal(t, big.NewInt(101), (*result)[0].Block.Number)
-	assert.Equal(t, big.NewInt(102), (*result)[1].Block.Number)
-	assert.Equal(t, big.NewInt(103), (*result)[2].Block.Number)
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, big.NewInt(101), result[0].Block.Number)
+	assert.Equal(t, big.NewInt(102), result[1].Block.Number)
+	assert.Equal(t, big.NewInt(103), result[2].Block.Number)
 }
 
 func TestCommit(t *testing.T) {
@@ -317,10 +317,10 @@ func TestCommit(t *testing.T) {
 		{Block: common.Block{Number: big.NewInt(102)}},
 	}
 
-	mockMainStorage.EXPECT().InsertBlockData(&blockData).Return(nil)
-	mockStagingStorage.EXPECT().DeleteStagingData(&blockData).Return(nil)
+	mockMainStorage.EXPECT().InsertBlockData(blockData).Return(nil)
+	mockStagingStorage.EXPECT().DeleteStagingData(blockData).Return(nil)
 
-	err := committer.commit(&blockData)
+	err := committer.commit(blockData)
 
 	assert.NoError(t, err)
 }
@@ -381,9 +381,9 @@ func TestStartCommitter(t *testing.T) {
 		{Block: common.Block{Number: big.NewInt(101)}},
 		{Block: common.Block{Number: big.NewInt(102)}},
 	}
-	mockStagingStorage.On("GetStagingData", mock.Anything).Return(&blockData, nil)
-	mockMainStorage.On("InsertBlockData", &blockData).Return(nil)
-	mockStagingStorage.On("DeleteStagingData", &blockData).Return(nil)
+	mockStagingStorage.On("GetStagingData", mock.Anything).Return(blockData, nil)
+	mockMainStorage.On("InsertBlockData", blockData).Return(nil)
+	mockStagingStorage.On("DeleteStagingData", blockData).Return(nil)
 
 	// Start the committer in a goroutine
 	go committer.Start(context.Background())
@@ -414,9 +414,9 @@ func TestCommitterRespectsSIGTERM(t *testing.T) {
 		{Block: common.Block{Number: big.NewInt(101)}},
 		{Block: common.Block{Number: big.NewInt(102)}},
 	}
-	mockStagingStorage.On("GetStagingData", mock.Anything).Return(&blockData, nil)
-	mockMainStorage.On("InsertBlockData", &blockData).Return(nil)
-	mockStagingStorage.On("DeleteStagingData", &blockData).Return(nil)
+	mockStagingStorage.On("GetStagingData", mock.Anything).Return(blockData, nil)
+	mockMainStorage.On("InsertBlockData", blockData).Return(nil)
+	mockStagingStorage.On("DeleteStagingData", blockData).Return(nil)
 
 	// Create a context that we can cancel
 	ctx, cancel := context.WithCancel(context.Background())
@@ -480,7 +480,7 @@ func TestHandleMissingStagingData(t *testing.T) {
 	mockStagingStorage.EXPECT().GetStagingData(storage.QueryFilter{
 		ChainId:      chainID,
 		BlockNumbers: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)},
-	}).Return(&blockData, nil)
+	}).Return(blockData, nil)
 
 	result, err := committer.getSequentialBlockDataToCommit()
 
@@ -524,7 +524,7 @@ func TestHandleMissingStagingDataIsPolledWithCorrectBatchSize(t *testing.T) {
 	mockStagingStorage.EXPECT().GetStagingData(storage.QueryFilter{
 		ChainId:      chainID,
 		BlockNumbers: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)},
-	}).Return(&blockData, nil)
+	}).Return(blockData, nil)
 
 	result, err := committer.getSequentialBlockDataToCommit()
 

--- a/internal/orchestrator/reorg_handler.go
+++ b/internal/orchestrator/reorg_handler.go
@@ -194,7 +194,7 @@ func (rh *ReorgHandler) findReorgedBlockNumbers(blockHeadersDescending []common.
 	continueCheckingForReorgs := false
 	for i := 0; i < len(blockHeadersDescending); i++ {
 		blockHeader := blockHeadersDescending[i]
-		fetchedBlock, ok := (*newBlocksByNumber)[blockHeader.Number.String()]
+		fetchedBlock, ok := newBlocksByNumber[blockHeader.Number.String()]
 		if !ok {
 			return fmt.Errorf("block not found: %s", blockHeader.Number.String())
 		}
@@ -220,7 +220,7 @@ func (rh *ReorgHandler) findReorgedBlockNumbers(blockHeadersDescending []common.
 	return nil
 }
 
-func (rh *ReorgHandler) getNewBlocksByNumber(blockHeaders []common.BlockHeader) (*map[string]common.Block, error) {
+func (rh *ReorgHandler) getNewBlocksByNumber(blockHeaders []common.BlockHeader) (map[string]common.Block, error) {
 	blockNumbers := make([]*big.Int, 0, len(blockHeaders))
 	for _, header := range blockHeaders {
 		blockNumbers = append(blockNumbers, header.Number)
@@ -257,7 +257,7 @@ func (rh *ReorgHandler) getNewBlocksByNumber(blockHeaders []common.BlockHeader) 
 			fetchedBlocksByNumber[blockResult.BlockNumber.String()] = blockResult.Data
 		}
 	}
-	return &fetchedBlocksByNumber, nil
+	return fetchedBlocksByNumber, nil
 }
 
 func (rh *ReorgHandler) handleReorg(reorgedBlockNumbers []*big.Int) error {
@@ -281,7 +281,7 @@ func (rh *ReorgHandler) handleReorg(reorgedBlockNumbers []*big.Int) error {
 	if err := rh.storage.MainStorage.DeleteBlockData(rh.rpc.GetChainID(), blocksToDelete); err != nil {
 		return fmt.Errorf("error deleting data for blocks %v: %w", blocksToDelete, err)
 	}
-	if err := rh.storage.MainStorage.InsertBlockData(&data); err != nil {
+	if err := rh.storage.MainStorage.InsertBlockData(data); err != nil {
 		return fmt.Errorf("error saving data to main storage: %w", err)
 	}
 	return nil

--- a/internal/orchestrator/reorg_handler_test.go
+++ b/internal/orchestrator/reorg_handler_test.go
@@ -614,8 +614,8 @@ func TestHandleReorgWithSingleBlockReorg(t *testing.T) {
 	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.MatchedBy(func(blocks []*big.Int) bool {
 		return len(blocks) == 1
 	})).Return(nil)
-	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data *[]common.BlockData) bool {
-		return data != nil && len(*data) == 1
+	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data []common.BlockData) bool {
+		return len(data) == 1
 	})).Return(nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
@@ -682,8 +682,8 @@ func TestHandleReorgWithLatestBlockReorged(t *testing.T) {
 	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.MatchedBy(func(blocks []*big.Int) bool {
 		return len(blocks) == 8
 	})).Return(nil)
-	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data *[]common.BlockData) bool {
-		return data != nil && len(*data) == 8
+	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data []common.BlockData) bool {
+		return len(data) == 8
 	})).Return(nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
@@ -746,8 +746,8 @@ func TestHandleReorgWithManyBlocks(t *testing.T) {
 	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.MatchedBy(func(blocks []*big.Int) bool {
 		return len(blocks) == 5
 	})).Return(nil)
-	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data *[]common.BlockData) bool {
-		return data != nil && len(*data) == 5
+	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data []common.BlockData) bool {
+		return len(data) == 5
 	})).Return(nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)

--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -212,29 +212,29 @@ func (rpc *Client) setChainID() error {
 
 func (rpc *Client) GetFullBlocks(blockNumbers []*big.Int) []GetFullBlockResult {
 	var wg sync.WaitGroup
-	var blocks *[]RPCFetchBatchResult[common.RawBlock]
-	var logs *[]RPCFetchBatchResult[common.RawLogs]
-	var traces *[]RPCFetchBatchResult[common.RawTraces]
-	var receipts *[]RPCFetchBatchResult[common.RawReceipts]
+	var blocks []RPCFetchBatchResult[common.RawBlock]
+	var logs []RPCFetchBatchResult[common.RawLogs]
+	var traces []RPCFetchBatchResult[common.RawTraces]
+	var receipts []RPCFetchBatchResult[common.RawReceipts]
 	wg.Add(2)
 
 	go func() {
 		defer wg.Done()
 		result := RPCFetchBatch[common.RawBlock](rpc, blockNumbers, "eth_getBlockByNumber", GetBlockWithTransactionsParams)
-		blocks = &result
+		blocks = result
 	}()
 
 	if rpc.supportsBlockReceipts {
 		go func() {
 			defer wg.Done()
 			result := RPCFetchInBatches[common.RawReceipts](rpc, blockNumbers, rpc.blocksPerRequest.Receipts, config.Cfg.RPC.BlockReceipts.BatchDelay, "eth_getBlockReceipts", GetBlockReceiptsParams)
-			receipts = &result
+			receipts = result
 		}()
 	} else {
 		go func() {
 			defer wg.Done()
 			result := RPCFetchInBatches[common.RawLogs](rpc, blockNumbers, rpc.blocksPerRequest.Logs, config.Cfg.RPC.Logs.BatchDelay, "eth_getLogs", GetLogsParams)
-			logs = &result
+			logs = result
 		}()
 	}
 
@@ -243,7 +243,7 @@ func (rpc *Client) GetFullBlocks(blockNumbers []*big.Int) []GetFullBlockResult {
 		go func() {
 			defer wg.Done()
 			result := RPCFetchInBatches[common.RawTraces](rpc, blockNumbers, rpc.blocksPerRequest.Traces, config.Cfg.RPC.Traces.BatchDelay, "trace_block", TraceBlockParams)
-			traces = &result
+			traces = result
 		}()
 	}
 

--- a/internal/rpc/serializer.go
+++ b/internal/rpc/serializer.go
@@ -11,17 +11,17 @@ import (
 	"github.com/thirdweb-dev/indexer/internal/common"
 )
 
-func SerializeFullBlocks(chainId *big.Int, blocks *[]RPCFetchBatchResult[common.RawBlock], logs *[]RPCFetchBatchResult[common.RawLogs], traces *[]RPCFetchBatchResult[common.RawTraces], receipts *[]RPCFetchBatchResult[common.RawReceipts]) []GetFullBlockResult {
+func SerializeFullBlocks(chainId *big.Int, blocks []RPCFetchBatchResult[common.RawBlock], logs []RPCFetchBatchResult[common.RawLogs], traces []RPCFetchBatchResult[common.RawTraces], receipts []RPCFetchBatchResult[common.RawReceipts]) []GetFullBlockResult {
 	if blocks == nil {
 		return []GetFullBlockResult{}
 	}
-	results := make([]GetFullBlockResult, 0, len(*blocks))
+	results := make([]GetFullBlockResult, 0, len(blocks))
 
 	rawLogsMap := mapBatchResultsByBlockNumber[common.RawLogs](logs)
 	rawReceiptsMap := mapBatchResultsByBlockNumber[common.RawReceipts](receipts)
 	rawTracesMap := mapBatchResultsByBlockNumber[common.RawTraces](traces)
 
-	for _, rawBlock := range *blocks {
+	for _, rawBlock := range blocks {
 		result := GetFullBlockResult{
 			BlockNumber: rawBlock.BlockNumber,
 		}
@@ -45,7 +45,7 @@ func SerializeFullBlocks(chainId *big.Int, blocks *[]RPCFetchBatchResult[common.
 			if rawReceipts.Error != nil {
 				result.Error = rawReceipts.Error
 			} else {
-				result.Data.Logs = serializeLogsFromReceipts(chainId, &rawReceipts.Result, result.Data.Block)
+				result.Data.Logs = serializeLogsFromReceipts(chainId, rawReceipts.Result, result.Data.Block)
 				result.Data.Transactions = serializeTransactions(chainId, rawBlock.Result["transactions"].([]interface{}), blockTimestamp, &rawReceipts.Result)
 			}
 		} else {
@@ -75,12 +75,12 @@ func SerializeFullBlocks(chainId *big.Int, blocks *[]RPCFetchBatchResult[common.
 	return results
 }
 
-func mapBatchResultsByBlockNumber[T any](results *[]RPCFetchBatchResult[T]) map[string]*RPCFetchBatchResult[T] {
+func mapBatchResultsByBlockNumber[T any](results []RPCFetchBatchResult[T]) map[string]*RPCFetchBatchResult[T] {
 	if results == nil {
 		return make(map[string]*RPCFetchBatchResult[T], 0)
 	}
-	resultsMap := make(map[string]*RPCFetchBatchResult[T], len(*results))
-	for _, result := range *results {
+	resultsMap := make(map[string]*RPCFetchBatchResult[T], len(results))
+	for _, result := range results {
 		resultsMap[result.BlockNumber.String()] = &result
 	}
 	return resultsMap
@@ -278,13 +278,13 @@ func ExtractFunctionSelector(s string) string {
 	return s[0:10]
 }
 
-func serializeLogsFromReceipts(chainId *big.Int, rawReceipts *[]map[string]interface{}, block common.Block) []common.Log {
+func serializeLogsFromReceipts(chainId *big.Int, rawReceipts []map[string]interface{}, block common.Block) []common.Log {
 	logs := make([]common.Log, 0)
 	if rawReceipts == nil {
 		return logs
 	}
 
-	for _, receipt := range *rawReceipts {
+	for _, receipt := range rawReceipts {
 		rawLogs, ok := receipt["logs"].([]interface{})
 		if !ok {
 			log.Debug().Msgf("Failed to serialize logs: %v", receipt["logs"])

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -114,11 +114,11 @@ func connectDB(cfg *config.ClickhouseConfig) (clickhouse.Conn, error) {
 	return conn, nil
 }
 
-func (c *ClickHouseConnector) insertBlocks(blocks *[]common.Block, opt InsertOptions) error {
-	if len(*blocks) == 0 {
+func (c *ClickHouseConnector) insertBlocks(blocks []common.Block, opt InsertOptions) error {
+	if len(blocks) == 0 {
 		return nil
 	}
-	tableName := c.getTableName((*blocks)[0].ChainId, "blocks")
+	tableName := c.getTableName(blocks[0].ChainId, "blocks")
 	columns := []string{
 		"chain_id", "block_number", "block_timestamp", "hash", "parent_hash", "sha3_uncles", "nonce",
 		"mix_hash", "miner", "state_root", "transactions_root", "receipts_root", "size", "logs_bloom",
@@ -129,10 +129,10 @@ func (c *ClickHouseConnector) insertBlocks(blocks *[]common.Block, opt InsertOpt
 		columns = append(columns, "insert_timestamp")
 	}
 	query := fmt.Sprintf("INSERT INTO %s.%s (%s)", c.cfg.Database, tableName, strings.Join(columns, ", "))
-	for i := 0; i < len(*blocks); i += c.cfg.MaxRowsPerInsert {
+	for i := 0; i < len(blocks); i += c.cfg.MaxRowsPerInsert {
 		end := i + c.cfg.MaxRowsPerInsert
-		if end > len(*blocks) {
-			end = len(*blocks)
+		if end > len(blocks) {
+			end = len(blocks)
 		}
 
 		batch, err := c.conn.PrepareBatch(context.Background(), query)
@@ -140,7 +140,7 @@ func (c *ClickHouseConnector) insertBlocks(blocks *[]common.Block, opt InsertOpt
 			return err
 		}
 
-		for _, block := range (*blocks)[i:end] {
+		for _, block := range blocks[i:end] {
 			args := []interface{}{
 				block.ChainId,
 				block.Number,
@@ -185,11 +185,11 @@ func (c *ClickHouseConnector) insertBlocks(blocks *[]common.Block, opt InsertOpt
 	return nil
 }
 
-func (c *ClickHouseConnector) insertTransactions(txs *[]common.Transaction, opt InsertOptions) error {
-	if len(*txs) == 0 {
+func (c *ClickHouseConnector) insertTransactions(txs []common.Transaction, opt InsertOptions) error {
+	if len(txs) == 0 {
 		return nil
 	}
-	tableName := c.getTableName((*txs)[0].ChainId, "transactions")
+	tableName := c.getTableName(txs[0].ChainId, "transactions")
 	columns := []string{
 		"chain_id", "hash", "nonce", "block_hash", "block_number", "block_timestamp", "transaction_index", "from_address", "to_address", "value", "gas",
 		"gas_price", "data", "function_selector", "max_fee_per_gas", "max_priority_fee_per_gas", "transaction_type", "r", "s", "v", "access_list",
@@ -199,10 +199,10 @@ func (c *ClickHouseConnector) insertTransactions(txs *[]common.Transaction, opt 
 		columns = append(columns, "insert_timestamp")
 	}
 	query := fmt.Sprintf("INSERT INTO %s.%s (%s)", c.cfg.Database, tableName, strings.Join(columns, ", "))
-	for i := 0; i < len(*txs); i += c.cfg.MaxRowsPerInsert {
+	for i := 0; i < len(txs); i += c.cfg.MaxRowsPerInsert {
 		end := i + c.cfg.MaxRowsPerInsert
-		if end > len(*txs) {
-			end = len(*txs)
+		if end > len(txs) {
+			end = len(txs)
 		}
 
 		batch, err := c.conn.PrepareBatch(context.Background(), query)
@@ -210,7 +210,7 @@ func (c *ClickHouseConnector) insertTransactions(txs *[]common.Transaction, opt 
 			return err
 		}
 
-		for _, tx := range (*txs)[i:end] {
+		for _, tx := range txs[i:end] {
 			args := []interface{}{
 				tx.ChainId,
 				tx.Hash,
@@ -264,11 +264,11 @@ func (c *ClickHouseConnector) insertTransactions(txs *[]common.Transaction, opt 
 	return nil
 }
 
-func (c *ClickHouseConnector) insertLogs(logs *[]common.Log, opt InsertOptions) error {
-	if len(*logs) == 0 {
+func (c *ClickHouseConnector) insertLogs(logs []common.Log, opt InsertOptions) error {
+	if len(logs) == 0 {
 		return nil
 	}
-	tableName := c.getTableName((*logs)[0].ChainId, "logs")
+	tableName := c.getTableName(logs[0].ChainId, "logs")
 	columns := []string{
 		"chain_id", "block_number", "block_hash", "block_timestamp", "transaction_hash", "transaction_index",
 		"log_index", "address", "data", "topic_0", "topic_1", "topic_2", "topic_3", "sign",
@@ -277,10 +277,10 @@ func (c *ClickHouseConnector) insertLogs(logs *[]common.Log, opt InsertOptions) 
 		columns = append(columns, "insert_timestamp")
 	}
 	query := fmt.Sprintf("INSERT INTO %s.%s (%s)", c.cfg.Database, tableName, strings.Join(columns, ", "))
-	for i := 0; i < len(*logs); i += c.cfg.MaxRowsPerInsert {
+	for i := 0; i < len(logs); i += c.cfg.MaxRowsPerInsert {
 		end := i + c.cfg.MaxRowsPerInsert
-		if end > len(*logs) {
-			end = len(*logs)
+		if end > len(logs) {
+			end = len(logs)
 		}
 
 		batch, err := c.conn.PrepareBatch(context.Background(), query)
@@ -288,7 +288,7 @@ func (c *ClickHouseConnector) insertLogs(logs *[]common.Log, opt InsertOptions) 
 			return err
 		}
 
-		for _, log := range (*logs)[i:end] {
+		for _, log := range logs[i:end] {
 			args := []interface{}{
 				log.ChainId,
 				log.BlockNumber,
@@ -326,11 +326,11 @@ func (c *ClickHouseConnector) insertLogs(logs *[]common.Log, opt InsertOptions) 
 	return nil
 }
 
-func (c *ClickHouseConnector) insertTraces(traces *[]common.Trace, opt InsertOptions) error {
-	if len(*traces) == 0 {
+func (c *ClickHouseConnector) insertTraces(traces []common.Trace, opt InsertOptions) error {
+	if len(traces) == 0 {
 		return nil
 	}
-	tableName := c.getTableName((*traces)[0].ChainID, "traces")
+	tableName := c.getTableName(traces[0].ChainID, "traces")
 	columns := []string{
 		"chain_id", "block_number", "block_hash", "block_timestamp", "transaction_hash", "transaction_index",
 		"subtraces", "trace_address", "type", "call_type", "error", "from_address", "to_address", "gas", "gas_used",
@@ -340,10 +340,10 @@ func (c *ClickHouseConnector) insertTraces(traces *[]common.Trace, opt InsertOpt
 		columns = append(columns, "insert_timestamp")
 	}
 	query := fmt.Sprintf("INSERT INTO %s.%s (%s)", c.cfg.Database, tableName, strings.Join(columns, ", "))
-	for i := 0; i < len(*traces); i += c.cfg.MaxRowsPerInsert {
+	for i := 0; i < len(traces); i += c.cfg.MaxRowsPerInsert {
 		end := i + c.cfg.MaxRowsPerInsert
-		if end > len(*traces) {
-			end = len(*traces)
+		if end > len(traces) {
+			end = len(traces)
 		}
 
 		batch, err := c.conn.PrepareBatch(context.Background(), query)
@@ -351,7 +351,7 @@ func (c *ClickHouseConnector) insertTraces(traces *[]common.Trace, opt InsertOpt
 			return err
 		}
 
-		for _, trace := range (*traces)[i:end] {
+		for _, trace := range traces[i:end] {
 			args := []interface{}{
 				trace.ChainID,
 				trace.BlockNumber,
@@ -882,7 +882,7 @@ func (c *ClickHouseConnector) InsertStagingData(data []common.BlockData) error {
 	return batch.Send()
 }
 
-func (c *ClickHouseConnector) GetStagingData(qf QueryFilter) (*[]common.BlockData, error) {
+func (c *ClickHouseConnector) GetStagingData(qf QueryFilter) ([]common.BlockData, error) {
 	query := fmt.Sprintf("SELECT data FROM %s.block_data WHERE block_number IN (%s) AND is_deleted = 0",
 		c.cfg.Database, getBlockNumbersStringArray(qf.BlockNumbers))
 
@@ -915,10 +915,10 @@ func (c *ClickHouseConnector) GetStagingData(qf QueryFilter) (*[]common.BlockDat
 		}
 		blockDataList = append(blockDataList, blockData)
 	}
-	return &blockDataList, nil
+	return blockDataList, nil
 }
 
-func (c *ClickHouseConnector) DeleteStagingData(data *[]common.BlockData) error {
+func (c *ClickHouseConnector) DeleteStagingData(data []common.BlockData) error {
 	query := fmt.Sprintf(`
         INSERT INTO %s.block_data (
             chain_id, block_number, is_deleted
@@ -930,7 +930,7 @@ func (c *ClickHouseConnector) DeleteStagingData(data *[]common.BlockData) error 
 		return err
 	}
 
-	for _, blockData := range *data {
+	for _, blockData := range data {
 		err := batch.Append(
 			blockData.Block.ChainId,
 			blockData.Block.Number,
@@ -1049,7 +1049,7 @@ func (c *ClickHouseConnector) deleteBlocks(chainId *big.Int, blockNumbers []*big
 	if len(blocksQueryResult.Data) == 0 {
 		return nil // No blocks to delete
 	}
-	return c.insertBlocks(&blocksQueryResult.Data, InsertOptions{
+	return c.insertBlocks(blocksQueryResult.Data, InsertOptions{
 		AsDeleted: true,
 	})
 }
@@ -1066,7 +1066,7 @@ func (c *ClickHouseConnector) deleteLogs(chainId *big.Int, blockNumbers []*big.I
 	if len(logsQueryResult.Data) == 0 {
 		return nil // No logs to delete
 	}
-	return c.insertLogs(&logsQueryResult.Data, InsertOptions{
+	return c.insertLogs(logsQueryResult.Data, InsertOptions{
 		AsDeleted: true,
 	})
 }
@@ -1083,7 +1083,7 @@ func (c *ClickHouseConnector) deleteTransactions(chainId *big.Int, blockNumbers 
 	if len(txsQueryResult.Data) == 0 {
 		return nil // No transactions to delete
 	}
-	return c.insertTransactions(&txsQueryResult.Data, InsertOptions{
+	return c.insertTransactions(txsQueryResult.Data, InsertOptions{
 		AsDeleted: true,
 	})
 }
@@ -1100,22 +1100,22 @@ func (c *ClickHouseConnector) deleteTraces(chainId *big.Int, blockNumbers []*big
 	if len(tracesQueryResult.Data) == 0 {
 		return nil // No traces to delete
 	}
-	return c.insertTraces(&tracesQueryResult.Data, InsertOptions{
+	return c.insertTraces(tracesQueryResult.Data, InsertOptions{
 		AsDeleted: true,
 	})
 }
 
 // TODO make this atomic
-func (c *ClickHouseConnector) InsertBlockData(data *[]common.BlockData) error {
-	if len(*data) == 0 {
+func (c *ClickHouseConnector) InsertBlockData(data []common.BlockData) error {
+	if len(data) == 0 {
 		return nil
 	}
-	blocks := make([]common.Block, 0, len(*data))
+	blocks := make([]common.Block, 0, len(data))
 	logs := make([]common.Log, 0)
 	transactions := make([]common.Transaction, 0)
 	traces := make([]common.Trace, 0)
 
-	for _, blockData := range *data {
+	for _, blockData := range data {
 		blocks = append(blocks, blockData.Block)
 		logs = append(logs, blockData.Logs...)
 		transactions = append(transactions, blockData.Transactions...)
@@ -1130,7 +1130,7 @@ func (c *ClickHouseConnector) InsertBlockData(data *[]common.BlockData) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := c.insertBlocks(&blocks, InsertOptions{
+			if err := c.insertBlocks(blocks, InsertOptions{
 				AsDeleted: false,
 			}); err != nil {
 				saveErrMutex.Lock()
@@ -1144,7 +1144,7 @@ func (c *ClickHouseConnector) InsertBlockData(data *[]common.BlockData) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := c.insertLogs(&logs, InsertOptions{
+			if err := c.insertLogs(logs, InsertOptions{
 				AsDeleted: false,
 			}); err != nil {
 				saveErrMutex.Lock()
@@ -1158,7 +1158,7 @@ func (c *ClickHouseConnector) InsertBlockData(data *[]common.BlockData) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := c.insertTransactions(&transactions, InsertOptions{
+			if err := c.insertTransactions(transactions, InsertOptions{
 				AsDeleted: false,
 			}); err != nil {
 				saveErrMutex.Lock()
@@ -1172,7 +1172,7 @@ func (c *ClickHouseConnector) InsertBlockData(data *[]common.BlockData) error {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			if err := c.insertTraces(&traces, InsertOptions{
+			if err := c.insertTraces(traces, InsertOptions{
 				AsDeleted: false,
 			}); err != nil {
 				saveErrMutex.Lock()

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -79,13 +79,13 @@ type IOrchestratorStorage interface {
 
 type IStagingStorage interface {
 	InsertStagingData(data []common.BlockData) error
-	GetStagingData(qf QueryFilter) (data *[]common.BlockData, err error)
-	DeleteStagingData(data *[]common.BlockData) error
+	GetStagingData(qf QueryFilter) (data []common.BlockData, err error)
+	DeleteStagingData(data []common.BlockData) error
 	GetLastStagedBlockNumber(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error)
 }
 
 type IMainStorage interface {
-	InsertBlockData(data *[]common.BlockData) error
+	InsertBlockData(data []common.BlockData) error
 
 	GetBlocks(qf QueryFilter, fields ...string) (blocks QueryResult[common.Block], err error)
 	GetTransactions(qf QueryFilter, fields ...string) (transactions QueryResult[common.Transaction], err error)

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -73,8 +73,8 @@ func (m *MemoryConnector) DeleteBlockFailures(failures []common.BlockFailure) er
 	return nil
 }
 
-func (m *MemoryConnector) insertBlocks(blocks *[]common.Block) error {
-	for _, block := range *blocks {
+func (m *MemoryConnector) insertBlocks(blocks []common.Block) error {
+	for _, block := range blocks {
 		blockJson, err := json.Marshal(block)
 		if err != nil {
 			return err
@@ -108,8 +108,8 @@ func (m *MemoryConnector) GetBlocks(qf QueryFilter, fields ...string) (QueryResu
 	return QueryResult[common.Block]{Data: blocks}, nil
 }
 
-func (m *MemoryConnector) insertTransactions(txs *[]common.Transaction) error {
-	for _, tx := range *txs {
+func (m *MemoryConnector) insertTransactions(txs []common.Transaction) error {
+	for _, tx := range txs {
 		txJson, err := json.Marshal(tx)
 		if err != nil {
 			return err
@@ -142,8 +142,8 @@ func (m *MemoryConnector) GetTransactions(qf QueryFilter, fields ...string) (Que
 	return QueryResult[common.Transaction]{Data: txs}, nil
 }
 
-func (m *MemoryConnector) insertLogs(logs *[]common.Log) error {
-	for _, log := range *logs {
+func (m *MemoryConnector) insertLogs(logs []common.Log) error {
+	for _, log := range logs {
 		logJson, err := json.Marshal(log)
 		if err != nil {
 			return err
@@ -270,7 +270,7 @@ func (m *MemoryConnector) InsertStagingData(data []common.BlockData) error {
 	return nil
 }
 
-func (m *MemoryConnector) GetStagingData(qf QueryFilter) (*[]common.BlockData, error) {
+func (m *MemoryConnector) GetStagingData(qf QueryFilter) ([]common.BlockData, error) {
 	blockData := []common.BlockData{}
 	limit := getLimit(qf)
 	blockNumbersToCheck := getBlockNumbersToCheck(qf)
@@ -291,19 +291,19 @@ func (m *MemoryConnector) GetStagingData(qf QueryFilter) (*[]common.BlockData, e
 			}
 		}
 	}
-	return &blockData, nil
+	return blockData, nil
 }
 
-func (m *MemoryConnector) DeleteStagingData(data *[]common.BlockData) error {
-	for _, blockData := range *data {
+func (m *MemoryConnector) DeleteStagingData(data []common.BlockData) error {
+	for _, blockData := range data {
 		key := fmt.Sprintf("blockData:%s:%s", blockData.Block.ChainId.String(), blockData.Block.Number.String())
 		m.cache.Remove(key)
 	}
 	return nil
 }
 
-func (m *MemoryConnector) insertTraces(traces *[]common.Trace) error {
-	for _, trace := range *traces {
+func (m *MemoryConnector) insertTraces(traces []common.Trace) error {
+	for _, trace := range traces {
 		traceJson, err := json.Marshal(trace)
 		if err != nil {
 			return err
@@ -407,29 +407,29 @@ func (m *MemoryConnector) SetLastReorgCheckedBlockNumber(chainId *big.Int, block
 	return nil
 }
 
-func (m *MemoryConnector) InsertBlockData(data *[]common.BlockData) error {
-	blocks := make([]common.Block, 0, len(*data))
+func (m *MemoryConnector) InsertBlockData(data []common.BlockData) error {
+	blocks := make([]common.Block, 0, len(data))
 	logs := make([]common.Log, 0)
 	transactions := make([]common.Transaction, 0)
 	traces := make([]common.Trace, 0)
 
-	for _, blockData := range *data {
+	for _, blockData := range data {
 		blocks = append(blocks, blockData.Block)
 		logs = append(logs, blockData.Logs...)
 		transactions = append(transactions, blockData.Transactions...)
 		traces = append(traces, blockData.Traces...)
 	}
 
-	if err := m.insertBlocks(&blocks); err != nil {
+	if err := m.insertBlocks(blocks); err != nil {
 		return err
 	}
-	if err := m.insertLogs(&logs); err != nil {
+	if err := m.insertLogs(logs); err != nil {
 		return err
 	}
-	if err := m.insertTransactions(&transactions); err != nil {
+	if err := m.insertTransactions(transactions); err != nil {
 		return err
 	}
-	if err := m.insertTraces(&traces); err != nil {
+	if err := m.insertTraces(traces); err != nil {
 		return err
 	}
 	return nil

--- a/test/mocks/MockIMainStorage.go
+++ b/test/mocks/MockIMainStorage.go
@@ -675,7 +675,7 @@ func (_c *MockIMainStorage_GetTransactions_Call) RunAndReturn(run func(storage.Q
 }
 
 // InsertBlockData provides a mock function with given fields: data
-func (_m *MockIMainStorage) InsertBlockData(data *[]common.BlockData) error {
+func (_m *MockIMainStorage) InsertBlockData(data []common.BlockData) error {
 	ret := _m.Called(data)
 
 	if len(ret) == 0 {
@@ -683,7 +683,7 @@ func (_m *MockIMainStorage) InsertBlockData(data *[]common.BlockData) error {
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]common.BlockData) error); ok {
+	if rf, ok := ret.Get(0).(func([]common.BlockData) error); ok {
 		r0 = rf(data)
 	} else {
 		r0 = ret.Error(0)
@@ -698,14 +698,14 @@ type MockIMainStorage_InsertBlockData_Call struct {
 }
 
 // InsertBlockData is a helper method to define mock.On call
-//   - data *[]common.BlockData
+//   - data []common.BlockData
 func (_e *MockIMainStorage_Expecter) InsertBlockData(data interface{}) *MockIMainStorage_InsertBlockData_Call {
 	return &MockIMainStorage_InsertBlockData_Call{Call: _e.mock.On("InsertBlockData", data)}
 }
 
-func (_c *MockIMainStorage_InsertBlockData_Call) Run(run func(data *[]common.BlockData)) *MockIMainStorage_InsertBlockData_Call {
+func (_c *MockIMainStorage_InsertBlockData_Call) Run(run func(data []common.BlockData)) *MockIMainStorage_InsertBlockData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*[]common.BlockData))
+		run(args[0].([]common.BlockData))
 	})
 	return _c
 }
@@ -715,7 +715,7 @@ func (_c *MockIMainStorage_InsertBlockData_Call) Return(_a0 error) *MockIMainSto
 	return _c
 }
 
-func (_c *MockIMainStorage_InsertBlockData_Call) RunAndReturn(run func(*[]common.BlockData) error) *MockIMainStorage_InsertBlockData_Call {
+func (_c *MockIMainStorage_InsertBlockData_Call) RunAndReturn(run func([]common.BlockData) error) *MockIMainStorage_InsertBlockData_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/test/mocks/MockIStagingStorage.go
+++ b/test/mocks/MockIStagingStorage.go
@@ -27,7 +27,7 @@ func (_m *MockIStagingStorage) EXPECT() *MockIStagingStorage_Expecter {
 }
 
 // DeleteStagingData provides a mock function with given fields: data
-func (_m *MockIStagingStorage) DeleteStagingData(data *[]common.BlockData) error {
+func (_m *MockIStagingStorage) DeleteStagingData(data []common.BlockData) error {
 	ret := _m.Called(data)
 
 	if len(ret) == 0 {
@@ -35,7 +35,7 @@ func (_m *MockIStagingStorage) DeleteStagingData(data *[]common.BlockData) error
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*[]common.BlockData) error); ok {
+	if rf, ok := ret.Get(0).(func([]common.BlockData) error); ok {
 		r0 = rf(data)
 	} else {
 		r0 = ret.Error(0)
@@ -50,14 +50,14 @@ type MockIStagingStorage_DeleteStagingData_Call struct {
 }
 
 // DeleteStagingData is a helper method to define mock.On call
-//   - data *[]common.BlockData
+//   - data []common.BlockData
 func (_e *MockIStagingStorage_Expecter) DeleteStagingData(data interface{}) *MockIStagingStorage_DeleteStagingData_Call {
 	return &MockIStagingStorage_DeleteStagingData_Call{Call: _e.mock.On("DeleteStagingData", data)}
 }
 
-func (_c *MockIStagingStorage_DeleteStagingData_Call) Run(run func(data *[]common.BlockData)) *MockIStagingStorage_DeleteStagingData_Call {
+func (_c *MockIStagingStorage_DeleteStagingData_Call) Run(run func(data []common.BlockData)) *MockIStagingStorage_DeleteStagingData_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*[]common.BlockData))
+		run(args[0].([]common.BlockData))
 	})
 	return _c
 }
@@ -67,7 +67,7 @@ func (_c *MockIStagingStorage_DeleteStagingData_Call) Return(_a0 error) *MockISt
 	return _c
 }
 
-func (_c *MockIStagingStorage_DeleteStagingData_Call) RunAndReturn(run func(*[]common.BlockData) error) *MockIStagingStorage_DeleteStagingData_Call {
+func (_c *MockIStagingStorage_DeleteStagingData_Call) RunAndReturn(run func([]common.BlockData) error) *MockIStagingStorage_DeleteStagingData_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -133,23 +133,23 @@ func (_c *MockIStagingStorage_GetLastStagedBlockNumber_Call) RunAndReturn(run fu
 }
 
 // GetStagingData provides a mock function with given fields: qf
-func (_m *MockIStagingStorage) GetStagingData(qf storage.QueryFilter) (*[]common.BlockData, error) {
+func (_m *MockIStagingStorage) GetStagingData(qf storage.QueryFilter) ([]common.BlockData, error) {
 	ret := _m.Called(qf)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetStagingData")
 	}
 
-	var r0 *[]common.BlockData
+	var r0 []common.BlockData
 	var r1 error
-	if rf, ok := ret.Get(0).(func(storage.QueryFilter) (*[]common.BlockData, error)); ok {
+	if rf, ok := ret.Get(0).(func(storage.QueryFilter) ([]common.BlockData, error)); ok {
 		return rf(qf)
 	}
-	if rf, ok := ret.Get(0).(func(storage.QueryFilter) *[]common.BlockData); ok {
+	if rf, ok := ret.Get(0).(func(storage.QueryFilter) []common.BlockData); ok {
 		r0 = rf(qf)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*[]common.BlockData)
+			r0 = ret.Get(0).([]common.BlockData)
 		}
 	}
 
@@ -180,12 +180,12 @@ func (_c *MockIStagingStorage_GetStagingData_Call) Run(run func(qf storage.Query
 	return _c
 }
 
-func (_c *MockIStagingStorage_GetStagingData_Call) Return(data *[]common.BlockData, err error) *MockIStagingStorage_GetStagingData_Call {
+func (_c *MockIStagingStorage_GetStagingData_Call) Return(data []common.BlockData, err error) *MockIStagingStorage_GetStagingData_Call {
 	_c.Call.Return(data, err)
 	return _c
 }
 
-func (_c *MockIStagingStorage_GetStagingData_Call) RunAndReturn(run func(storage.QueryFilter) (*[]common.BlockData, error)) *MockIStagingStorage_GetStagingData_Call {
+func (_c *MockIStagingStorage_GetStagingData_Call) RunAndReturn(run func(storage.QueryFilter) ([]common.BlockData, error)) *MockIStagingStorage_GetStagingData_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR

Refactored BlockData handling to use value types instead of pointers for slices, improving code clarity and reducing unnecessary pointer indirection.

### What changed?

This PR changes the signature of several functions across the codebase to use value types for slices instead of pointers to slices. Specifically:

- Changed `*[]common.BlockData` to `[]common.BlockData` in function parameters and return types
- Changed `*[]common.Block`, `*[]common.Transaction`, `*[]common.Log`, and `*[]common.Trace` to their value counterparts
- Updated all related function calls and implementations to match the new signatures
- Simplified nil checks by using `len()` directly on slices instead of checking for nil pointers first
- Updated mock implementations to reflect these changes

### How to test?

- Run the existing test suite to ensure all functionality works as expected
- Verify that the committer and reorg handler components function correctly with the new type signatures
- Check that storage operations (insert, get, delete) work properly with the refactored types

### Why make this change?

Using pointers to slices was unnecessary and added complexity to the codebase. This change:

1. Improves code readability by removing a layer of indirection
2. Makes the code more idiomatic Go by using value types for slices
3. Simplifies nil checks and length checks on collections
4. Reduces the risk of nil pointer dereferences
5. Makes the API more consistent and easier to understand

The change is purely refactoring and doesn't alter any business logic or functionality.