### PR TITLE
return block data when deleting it

### DIFF
--- a/internal/orchestrator/reorg_handler.go
+++ b/internal/orchestrator/reorg_handler.go
@@ -278,7 +278,7 @@ func (rh *ReorgHandler) handleReorg(reorgedBlockNumbers []*big.Int) error {
 		blocksToDelete = append(blocksToDelete, result.BlockNumber)
 	}
 	// TODO make delete and insert atomic
-	if err := rh.storage.MainStorage.DeleteBlockData(rh.rpc.GetChainID(), blocksToDelete); err != nil {
+	if _, err := rh.storage.MainStorage.DeleteBlockData(rh.rpc.GetChainID(), blocksToDelete); err != nil {
 		return fmt.Errorf("error deleting data for blocks %v: %w", blocksToDelete, err)
 	}
 	if err := rh.storage.MainStorage.InsertBlockData(data); err != nil {

--- a/internal/orchestrator/reorg_handler_test.go
+++ b/internal/orchestrator/reorg_handler_test.go
@@ -504,7 +504,7 @@ func TestHandleReorg(t *testing.T) {
 	})
 	mockOrchestratorStorage.EXPECT().GetLastReorgCheckedBlockNumber(big.NewInt(1)).Return(big.NewInt(3), nil)
 
-	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.Anything).Return(nil)
+	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.Anything).Return([]common.BlockData{}, nil)
 	mockMainStorage.EXPECT().InsertBlockData(mock.Anything).Return(nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
@@ -613,7 +613,7 @@ func TestHandleReorgWithSingleBlockReorg(t *testing.T) {
 
 	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.MatchedBy(func(blocks []*big.Int) bool {
 		return len(blocks) == 1
-	})).Return(nil)
+	})).Return([]common.BlockData{}, nil)
 	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data []common.BlockData) bool {
 		return len(data) == 1
 	})).Return(nil)
@@ -681,7 +681,7 @@ func TestHandleReorgWithLatestBlockReorged(t *testing.T) {
 
 	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.MatchedBy(func(blocks []*big.Int) bool {
 		return len(blocks) == 8
-	})).Return(nil)
+	})).Return([]common.BlockData{}, nil)
 	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data []common.BlockData) bool {
 		return len(data) == 8
 	})).Return(nil)
@@ -745,7 +745,7 @@ func TestHandleReorgWithManyBlocks(t *testing.T) {
 
 	mockMainStorage.EXPECT().DeleteBlockData(big.NewInt(1), mock.MatchedBy(func(blocks []*big.Int) bool {
 		return len(blocks) == 5
-	})).Return(nil)
+	})).Return([]common.BlockData{}, nil)
 	mockMainStorage.EXPECT().InsertBlockData(mock.MatchedBy(func(data []common.BlockData) bool {
 		return len(data) == 5
 	})).Return(nil)

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -97,7 +97,7 @@ type IMainStorage interface {
 	 * Get block headers ordered from latest to oldest.
 	 */
 	GetBlockHeadersDescending(chainId *big.Int, from *big.Int, to *big.Int) (blockHeaders []common.BlockHeader, err error)
-	DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) error
+	DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) ([]common.BlockData, error)
 
 	GetTokenBalances(qf BalancesQueryFilter, fields ...string) (QueryResult[common.TokenBalance], error)
 	GetTokenTransfers(qf TransfersQueryFilter, fields ...string) (QueryResult[common.TokenTransfer], error)

--- a/internal/storage/memory.go
+++ b/internal/storage/memory.go
@@ -435,7 +435,7 @@ func (m *MemoryConnector) InsertBlockData(data []common.BlockData) error {
 	return nil
 }
 
-func (m *MemoryConnector) DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) error {
+func (m *MemoryConnector) DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) ([]common.BlockData, error) {
 	blockNumbersToCheck := getBlockNumbersToCheck(QueryFilter{BlockNumbers: blockNumbers})
 	for _, key := range m.cache.Keys() {
 		prefixes := []string{fmt.Sprintf("block:%s:", chainId.String()), fmt.Sprintf("log:%s:", chainId.String()), fmt.Sprintf("transaction:%s:", chainId.String()), fmt.Sprintf("trace:%s:", chainId.String())}
@@ -444,7 +444,7 @@ func (m *MemoryConnector) DeleteBlockData(chainId *big.Int, blockNumbers []*big.
 			m.cache.Remove(key)
 		}
 	}
-	return nil
+	return []common.BlockData{}, nil // TODO implement
 }
 
 func (m *MemoryConnector) GetBlockHeadersDescending(chainId *big.Int, from *big.Int, to *big.Int) ([]common.BlockHeader, error) {

--- a/test/mocks/MockIMainStorage.go
+++ b/test/mocks/MockIMainStorage.go
@@ -27,21 +27,33 @@ func (_m *MockIMainStorage) EXPECT() *MockIMainStorage_Expecter {
 }
 
 // DeleteBlockData provides a mock function with given fields: chainId, blockNumbers
-func (_m *MockIMainStorage) DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) error {
+func (_m *MockIMainStorage) DeleteBlockData(chainId *big.Int, blockNumbers []*big.Int) ([]common.BlockData, error) {
 	ret := _m.Called(chainId, blockNumbers)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteBlockData")
 	}
 
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*big.Int, []*big.Int) error); ok {
+	var r0 []common.BlockData
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*big.Int, []*big.Int) ([]common.BlockData, error)); ok {
+		return rf(chainId, blockNumbers)
+	}
+	if rf, ok := ret.Get(0).(func(*big.Int, []*big.Int) []common.BlockData); ok {
 		r0 = rf(chainId, blockNumbers)
 	} else {
-		r0 = ret.Error(0)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]common.BlockData)
+		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(*big.Int, []*big.Int) error); ok {
+		r1 = rf(chainId, blockNumbers)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockIMainStorage_DeleteBlockData_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteBlockData'
@@ -63,12 +75,12 @@ func (_c *MockIMainStorage_DeleteBlockData_Call) Run(run func(chainId *big.Int, 
 	return _c
 }
 
-func (_c *MockIMainStorage_DeleteBlockData_Call) Return(_a0 error) *MockIMainStorage_DeleteBlockData_Call {
-	_c.Call.Return(_a0)
+func (_c *MockIMainStorage_DeleteBlockData_Call) Return(_a0 []common.BlockData, _a1 error) *MockIMainStorage_DeleteBlockData_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockIMainStorage_DeleteBlockData_Call) RunAndReturn(run func(*big.Int, []*big.Int) error) *MockIMainStorage_DeleteBlockData_Call {
+func (_c *MockIMainStorage_DeleteBlockData_Call) RunAndReturn(run func(*big.Int, []*big.Int) ([]common.BlockData, error)) *MockIMainStorage_DeleteBlockData_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR

Enhanced `DeleteBlockData` to return deleted block data, enabling better handling of reorgs.

### What changed?

Modified the `DeleteBlockData` method in the storage interface to return the deleted block data:
- Updated the method signature in `IMainStorage` interface to return `([]common.BlockData, error)`
- Implemented the new functionality in `ClickHouseConnector` to collect and return deleted data
- Modified the individual delete methods (`deleteBlocks`, `deleteLogs`, etc.) to return the deleted entities
- Updated the `MemoryConnector` implementation to match the new interface
- Fixed the mock implementation to support the new signature
- Updated the caller in `ReorgHandler` to handle the new return value

### How to test?

1. Run unit tests to verify the updated interface implementations
2. Test a reorg scenario to ensure deleted block data is properly returned
3. Verify that the reorg handler correctly processes the returned data

### Why make this change?

This change improves the reorg handling process by providing access to the deleted block data, which can be useful for:
- Auditing what was removed during a reorg
- Potentially using the deleted data for other purposes
- Making the reorg process more transparent and traceable
- Setting the foundation for making delete and insert operations atomic