### PR TITLE
feat: tokens route for getting IDs

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -92,6 +92,9 @@ func RunApi(cmd *cobra.Command, args []string) {
 		// token holder queries
 		root.GET("/holders/:address", handlers.GetTokenHoldersByType)
 
+		// token ID queries
+		root.GET("/tokens/:address", handlers.GetTokenIdsByType)
+
 		// search
 		root.GET("/search/:input", handlers.Search)
 	}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -747,7 +747,7 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Type of token",
                         "name": "token_type",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "boolean",
@@ -785,6 +785,109 @@ const docTemplate = `{
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/definitions/handlers.HolderModel"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/{chainId}/tokens/{address}": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve token IDs by type for a specific token address",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tokens"
+                ],
+                "summary": "Get token IDs by type for a specific token address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Chain ID",
+                        "name": "chainId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Token address",
+                        "name": "address",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Type of token (erc721 or erc1155)",
+                        "name": "token_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Hide zero balances",
+                        "name": "hide_zero_balances",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TokenIdModel"
                                             }
                                         }
                                     }
@@ -1359,10 +1462,16 @@ const docTemplate = `{
                 "indexedParams": {
                     "type": "object"
                 },
+                "indexed_params": {
+                    "type": "object"
+                },
                 "name": {
                     "type": "string"
                 },
                 "nonIndexedParams": {
+                    "type": "object"
+                },
+                "non_indexed_params": {
                     "type": "object"
                 },
                 "signature": {
@@ -1678,6 +1787,9 @@ const docTemplate = `{
                 },
                 "token_id": {
                     "type": "string"
+                },
+                "token_type": {
+                    "type": "string"
                 }
             }
         },
@@ -1691,6 +1803,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "token_id": {
+                    "type": "string"
+                },
+                "token_type": {
                     "type": "string"
                 }
             }
@@ -1739,6 +1854,17 @@ const docTemplate = `{
                 "SearchResultTypeAddress",
                 "SearchResultTypeContract"
             ]
+        },
+        "handlers.TokenIdModel": {
+            "type": "object",
+            "properties": {
+                "token_id": {
+                    "type": "string"
+                },
+                "token_type": {
+                    "type": "string"
+                }
+            }
         }
     },
     "securityDefinitions": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -740,7 +740,7 @@
                         "type": "string",
                         "description": "Type of token",
                         "name": "token_type",
-                        "in": "path"
+                        "in": "query"
                     },
                     {
                         "type": "boolean",
@@ -778,6 +778,109 @@
                                             "type": "array",
                                             "items": {
                                                 "$ref": "#/definitions/handlers.HolderModel"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
+        },
+        "/{chainId}/tokens/{address}": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve token IDs by type for a specific token address",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "tokens"
+                ],
+                "summary": "Get token IDs by type for a specific token address",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Chain ID",
+                        "name": "chainId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Token address",
+                        "name": "address",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Type of token (erc721 or erc1155)",
+                        "name": "token_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Hide zero balances",
+                        "name": "hide_zero_balances",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TokenIdModel"
                                             }
                                         }
                                     }
@@ -1352,10 +1455,16 @@
                 "indexedParams": {
                     "type": "object"
                 },
+                "indexed_params": {
+                    "type": "object"
+                },
                 "name": {
                     "type": "string"
                 },
                 "nonIndexedParams": {
+                    "type": "object"
+                },
+                "non_indexed_params": {
                     "type": "object"
                 },
                 "signature": {
@@ -1671,6 +1780,9 @@
                 },
                 "token_id": {
                     "type": "string"
+                },
+                "token_type": {
+                    "type": "string"
                 }
             }
         },
@@ -1684,6 +1796,9 @@
                     "type": "string"
                 },
                 "token_id": {
+                    "type": "string"
+                },
+                "token_type": {
                     "type": "string"
                 }
             }
@@ -1732,6 +1847,17 @@
                 "SearchResultTypeAddress",
                 "SearchResultTypeContract"
             ]
+        },
+        "handlers.TokenIdModel": {
+            "type": "object",
+            "properties": {
+                "token_id": {
+                    "type": "string"
+                },
+                "token_type": {
+                    "type": "string"
+                }
+            }
         }
     },
     "securityDefinitions": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -103,10 +103,14 @@ definitions:
     type: object
   common.DecodedLogDataModel:
     properties:
+      indexed_params:
+        type: object
       indexedParams:
         type: object
       name:
         type: string
+      non_indexed_params:
+        type: object
       nonIndexedParams:
         type: object
       signature:
@@ -314,6 +318,8 @@ definitions:
         type: string
       token_id:
         type: string
+      token_type:
+        type: string
     type: object
   handlers.HolderModel:
     properties:
@@ -322,6 +328,8 @@ definitions:
       holder_address:
         type: string
       token_id:
+        type: string
+      token_type:
         type: string
     type: object
   handlers.SearchResultModel:
@@ -357,6 +365,13 @@ definitions:
     - SearchResultTypeFunctionSignature
     - SearchResultTypeAddress
     - SearchResultTypeContract
+  handlers.TokenIdModel:
+    properties:
+      token_id:
+        type: string
+      token_type:
+        type: string
+    type: object
 info:
   contact: {}
   description: API for querying blockchain transactions and events
@@ -778,7 +793,7 @@ paths:
         required: true
         type: string
       - description: Type of token
-        in: path
+        in: query
         name: token_type
         type: string
       - description: Hide zero balances
@@ -826,6 +841,71 @@ paths:
       summary: Get holders of a token
       tags:
       - holders
+  /{chainId}/tokens/{address}:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve token IDs by type for a specific token address
+      parameters:
+      - description: Chain ID
+        in: path
+        name: chainId
+        required: true
+        type: string
+      - description: Token address
+        in: path
+        name: address
+        required: true
+        type: string
+      - description: Type of token (erc721 or erc1155)
+        in: query
+        name: token_type
+        type: string
+      - description: Hide zero balances
+        in: query
+        name: hide_zero_balances
+        required: true
+        type: boolean
+      - description: Page number for pagination
+        in: query
+        name: page
+        type: integer
+      - default: 5
+        description: Number of items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.QueryResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.TokenIdModel'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      security:
+      - BasicAuth: []
+      summary: Get token IDs by type for a specific token address
+      tags:
+      - tokens
   /{chainId}/transactions:
     get:
       consumes:

--- a/internal/handlers/token_handlers.go
+++ b/internal/handlers/token_handlers.go
@@ -12,7 +12,7 @@ import (
 	"github.com/thirdweb-dev/indexer/internal/storage"
 )
 
-// BalanceModel return type for Swagger documentation
+// Models return type for Swagger documentation
 type BalanceModel struct {
 	TokenAddress string `json:"token_address" ch:"address"`
 	TokenId      string `json:"token_id" ch:"token_id"`
@@ -20,11 +20,116 @@ type BalanceModel struct {
 	TokenType    string `json:"token_type" ch:"token_type"`
 }
 
+type TokenIdModel struct {
+	TokenId   string `json:"token_id" ch:"token_id"`
+	TokenType string `json:"token_type" ch:"token_type"`
+}
+
 type HolderModel struct {
 	HolderAddress string `json:"holder_address" ch:"owner"`
 	TokenId       string `json:"token_id" ch:"token_id"`
 	Balance       string `json:"balance" ch:"balance"`
 	TokenType     string `json:"token_type" ch:"token_type"`
+}
+
+// @Summary Get token IDs by type for a specific token address
+// @Description Retrieve token IDs by type for a specific token address
+// @Tags tokens
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param chainId path string true "Chain ID"
+// @Param address path string true "Token address"
+// @Param token_type query string false "Type of token (erc721 or erc1155)"
+// @Param hide_zero_balances query bool true "Hide zero balances"
+// @Param page query int false "Page number for pagination"
+// @Param limit query int false "Number of items per page" default(5)
+// @Success 200 {object} api.QueryResponse{data=[]TokenIdModel}
+// @Failure 400 {object} api.Error
+// @Failure 401 {object} api.Error
+// @Failure 500 {object} api.Error
+// @Router /{chainId}/tokens/{address} [get]
+func GetTokenIdsByType(c *gin.Context) {
+	chainId, err := api.GetChainId(c)
+	if err != nil {
+		api.BadRequestErrorHandler(c, err)
+		return
+	}
+
+	address := strings.ToLower(c.Param("address"))
+	if !strings.HasPrefix(address, "0x") {
+		api.BadRequestErrorHandler(c, fmt.Errorf("invalid token address '%s'", address))
+		return
+	}
+
+	tokenTypes, err := getTokenTypesFromReq(c)
+	if err != nil {
+		api.BadRequestErrorHandler(c, err)
+		return
+	}
+
+	// Filter out erc20 tokens as they don't have token IDs
+	filteredTokenTypes := []string{}
+	for _, tokenType := range tokenTypes {
+		if tokenType == "erc721" || tokenType == "erc1155" {
+			filteredTokenTypes = append(filteredTokenTypes, tokenType)
+		}
+	}
+
+	if len(filteredTokenTypes) == 0 {
+		// Default to both ERC721 and ERC1155 if no valid token types specified
+		filteredTokenTypes = []string{"erc721", "erc1155"}
+	}
+
+	hideZeroBalances := c.Query("hide_zero_balances") != "false"
+
+	// We only care about token_id and token_type
+	columns := []string{"token_id", "token_type"}
+	groupBy := []string{"token_id", "token_type"}
+
+	tokenIds, err := getTokenIdsFromReq(c)
+	if err != nil {
+		api.BadRequestErrorHandler(c, fmt.Errorf("invalid token ids '%s'", err))
+		return
+	}
+
+	qf := storage.BalancesQueryFilter{
+		ChainId:      chainId,
+		TokenTypes:   filteredTokenTypes,
+		TokenAddress: address,
+		ZeroBalance:  hideZeroBalances,
+		TokenIds:     tokenIds,
+		GroupBy:      groupBy,
+		SortBy:       c.Query("sort_by"),
+		SortOrder:    c.Query("sort_order"),
+		Page:         api.ParseIntQueryParam(c.Query("page"), 0),
+		Limit:        api.ParseIntQueryParam(c.Query("limit"), 0),
+	}
+
+	queryResult := api.QueryResponse{
+		Meta: api.Meta{
+			ChainId: chainId.Uint64(),
+			Page:    qf.Page,
+			Limit:   qf.Limit,
+		},
+	}
+
+	mainStorage, err = getMainStorage()
+	if err != nil {
+		log.Error().Err(err).Msg("Error getting main storage")
+		api.InternalErrorHandler(c)
+		return
+	}
+
+	balancesResult, err := mainStorage.GetTokenBalances(qf, columns...)
+	if err != nil {
+		log.Error().Err(err).Msg("Error querying token IDs")
+		api.InternalErrorHandler(c)
+		return
+	}
+
+	queryResult.Data = serializeTokenIds(balancesResult.Data)
+	sendJSONResponse(c, queryResult)
 }
 
 // @Summary Get token balances of an address by type
@@ -123,65 +228,6 @@ func GetTokenBalancesByType(c *gin.Context) {
 	sendJSONResponse(c, queryResult)
 }
 
-func serializeBalances(balances []common.TokenBalance) []BalanceModel {
-	balanceModels := make([]BalanceModel, len(balances))
-	for i, balance := range balances {
-		balanceModels[i] = serializeBalance(balance)
-	}
-	return balanceModels
-}
-
-func serializeBalance(balance common.TokenBalance) BalanceModel {
-	return BalanceModel{
-		TokenAddress: balance.TokenAddress,
-		Balance:      balance.Balance.String(),
-		TokenId: func() string {
-			if balance.TokenId != nil {
-				return balance.TokenId.String()
-			}
-			return ""
-		}(),
-		TokenType: balance.TokenType,
-	}
-}
-
-func getTokenTypesFromReq(c *gin.Context) ([]string, error) {
-	tokenTypeParam := c.Param("type")
-	var tokenTypes []string
-	if tokenTypeParam != "" {
-		tokenTypes = []string{tokenTypeParam}
-	} else {
-		tokenTypes = c.QueryArray("token_type")
-	}
-
-	for i, tokenType := range tokenTypes {
-		tokenType = strings.ToLower(tokenType)
-		if tokenType != "erc721" && tokenType != "erc1155" && tokenType != "erc20" {
-			return []string{}, fmt.Errorf("invalid token type: %s", tokenType)
-		}
-		tokenTypes[i] = tokenType
-	}
-	return tokenTypes, nil
-}
-
-func getTokenIdsFromReq(c *gin.Context) ([]*big.Int, error) {
-	tokenIds := c.QueryArray("token_id")
-	tokenIdsBn := make([]*big.Int, len(tokenIds))
-	for i, tokenId := range tokenIds {
-		tokenId = strings.TrimSpace(tokenId) // Remove potential whitespace
-		if tokenId == "" {
-			return nil, fmt.Errorf("invalid token id: %s", tokenId)
-		}
-		num := new(big.Int)
-		_, ok := num.SetString(tokenId, 10) // Base 10
-		if !ok {
-			return nil, fmt.Errorf("invalid token id: %s", tokenId)
-		}
-		tokenIdsBn[i] = num
-	}
-	return tokenIdsBn, nil
-}
-
 // @Summary Get holders of a token
 // @Description Retrieve holders of a token
 // @Tags holders
@@ -190,7 +236,7 @@ func getTokenIdsFromReq(c *gin.Context) ([]*big.Int, error) {
 // @Security BasicAuth
 // @Param chainId path string true "Chain ID"
 // @Param address path string true "Address of the token"
-// @Param token_type path string false "Type of token"
+// @Param token_type query string false "Type of token"
 // @Param hide_zero_balances query bool true "Hide zero balances"
 // @Param page query int false "Page number for pagination"
 // @Param limit query int false "Number of items per page" default(5)
@@ -271,6 +317,65 @@ func GetTokenHoldersByType(c *gin.Context) {
 	sendJSONResponse(c, queryResult)
 }
 
+func serializeBalances(balances []common.TokenBalance) []BalanceModel {
+	balanceModels := make([]BalanceModel, len(balances))
+	for i, balance := range balances {
+		balanceModels[i] = serializeBalance(balance)
+	}
+	return balanceModels
+}
+
+func serializeBalance(balance common.TokenBalance) BalanceModel {
+	return BalanceModel{
+		TokenAddress: balance.TokenAddress,
+		Balance:      balance.Balance.String(),
+		TokenId: func() string {
+			if balance.TokenId != nil {
+				return balance.TokenId.String()
+			}
+			return ""
+		}(),
+		TokenType: balance.TokenType,
+	}
+}
+
+func getTokenTypesFromReq(c *gin.Context) ([]string, error) {
+	tokenTypeParam := c.Param("type")
+	var tokenTypes []string
+	if tokenTypeParam != "" {
+		tokenTypes = []string{tokenTypeParam}
+	} else {
+		tokenTypes = c.QueryArray("token_type")
+	}
+
+	for i, tokenType := range tokenTypes {
+		tokenType = strings.ToLower(tokenType)
+		if tokenType != "erc721" && tokenType != "erc1155" && tokenType != "erc20" {
+			return []string{}, fmt.Errorf("invalid token type: %s", tokenType)
+		}
+		tokenTypes[i] = tokenType
+	}
+	return tokenTypes, nil
+}
+
+func getTokenIdsFromReq(c *gin.Context) ([]*big.Int, error) {
+	tokenIds := c.QueryArray("token_id")
+	tokenIdsBn := make([]*big.Int, len(tokenIds))
+	for i, tokenId := range tokenIds {
+		tokenId = strings.TrimSpace(tokenId) // Remove potential whitespace
+		if tokenId == "" {
+			return nil, fmt.Errorf("invalid token id: %s", tokenId)
+		}
+		num := new(big.Int)
+		_, ok := num.SetString(tokenId, 10) // Base 10
+		if !ok {
+			return nil, fmt.Errorf("invalid token id: %s", tokenId)
+		}
+		tokenIdsBn[i] = num
+	}
+	return tokenIdsBn, nil
+}
+
 func serializeHolders(holders []common.TokenBalance) []HolderModel {
 	holderModels := make([]HolderModel, len(holders))
 	for i, holder := range holders {
@@ -290,5 +395,25 @@ func serializeHolder(holder common.TokenBalance) HolderModel {
 			return ""
 		}(),
 		TokenType: holder.TokenType,
+	}
+}
+
+func serializeTokenIds(balances []common.TokenBalance) []TokenIdModel {
+	tokenIdModels := make([]TokenIdModel, len(balances))
+	for i, balance := range balances {
+		tokenIdModels[i] = serializeTokenId(balance)
+	}
+	return tokenIdModels
+}
+
+func serializeTokenId(balance common.TokenBalance) TokenIdModel {
+	return TokenIdModel{
+		TokenId: func() string {
+			if balance.TokenId != nil {
+				return balance.TokenId.String()
+			}
+			return ""
+		}(),
+		TokenType: balance.TokenType,
 	}
 }


### PR DESCRIPTION
### TL;DR

Added a new API endpoint to retrieve token IDs by type for a specific contract address.

### What changed?

- Added a new API endpoint `GET /{chainId}/tokens/{address}` to retrieve token IDs by type (ERC721 or ERC1155) for a specific token address
- Created a new `TokenIdModel` struct to represent token ID data in the response
- Updated Swagger documentation to include the new endpoint and model
- Fixed a parameter location in the documentation for the token holders endpoint (changed `token_type` from path to query parameter)
- Added serialisation functions for token IDs

### How to test?

1. Start the API server
2. Make a GET request to `/{chainId}/tokens/{address}` with the following parameters:
   - `token_type`: Optional filter for token type (erc721 or erc1155)
   - `hide_zero_balances`: Boolean to filter out zero balances
   - `page` and `limit`: For pagination
3. Verify the response contains token IDs and their types for the specified token address

### Why make this change?

This endpoint allows clients to retrieve all token IDs for a specific token contract address, which is useful for applications that need to display or work with all tokens from a particular collection. The endpoint complements the existing token holders endpoint by providing a different view of the token data.