### PR TITLE
fix ci actions with commit hash

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 # v5.7.0
         with:
           images: ${{ vars.DOCKER_IMAGE }}
           tags: |
@@ -31,7 +31,7 @@ jobs:
             type=semver,pattern={{version}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
         with:
           context: .
           push: true

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '1.23'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
           go-version: '1.23'
 


### PR DESCRIPTION
### TL;DR

Pin GitHub Actions to specific commit hashes for improved security and stability.

### What changed?

Updated all GitHub Actions in workflow files to use pinned commit hashes instead of version tags:
- `actions/checkout` pinned to `11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
- `docker/setup-buildx-action` pinned to `b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2` (v3.10.0)
- `docker/login-action` pinned to `74a5d142397b4f367a81961eba4e8cd7edddf772` (v3.4.0)
- `docker/metadata-action` pinned to `902fa8ec7d6ecbf8d84d538b9b233a880e428804` (v5.7.0)
- `docker/build-push-action` pinned to `471d1dc4e07e5cdedd4c2171150001c434f0b7a4` (v6.15.0)
- `actions/setup-go` pinned to `f111f3307d8850f501ac008e886eec1fd1932a34` (v5.3.0)

### How to test?

Run the GitHub workflows to verify they continue to function as expected:
- Trigger a test workflow
- Verify the format workflow
- Test the Docker release workflow if possible

### Why make this change?

Pinning GitHub Actions to specific commit hashes rather than version tags improves security by preventing supply chain attacks. It also ensures workflow stability by guaranteeing the exact version of each action being used, eliminating the risk of unexpected changes when actions are updated.