### PR TITLE
fix serialized types causing overflow

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1305,6 +1305,151 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/{chainId}/transfers": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve token transfers by various filters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transfers"
+                ],
+                "summary": "Get token transfers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Chain ID",
+                        "name": "chainId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Token types (erc721, erc1155, erc20)",
+                        "name": "token_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Token contract address",
+                        "name": "token_address",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Wallet address",
+                        "name": "wallet",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start block number",
+                        "name": "start_block",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End block number",
+                        "name": "end_block",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start timestamp (RFC3339 format)",
+                        "name": "start_timestamp",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End timestamp (RFC3339 format)",
+                        "name": "end_timestamp",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Token IDs",
+                        "name": "token_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transaction hash",
+                        "name": "transaction_hash",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TransferModel"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1410,10 +1555,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "gas_limit": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "gas_used": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "logs_bloom": {
                     "type": "string"
@@ -1550,7 +1695,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "blob_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "blob_gas_used": {
                     "type": "integer"
@@ -1588,7 +1733,7 @@ const docTemplate = `{
                     ]
                 },
                 "effective_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "from_address": {
                     "type": "string"
@@ -1600,7 +1745,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "gas_used": {
                     "type": "integer"
@@ -1612,10 +1757,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "max_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "max_priority_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "nonce": {
                     "type": "integer"
@@ -1642,7 +1787,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         },
@@ -1691,7 +1836,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "blob_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "blob_gas_used": {
                     "type": "integer"
@@ -1718,7 +1863,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "effective_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "from_address": {
                     "type": "string"
@@ -1730,7 +1875,7 @@ const docTemplate = `{
                     "type": "integer"
                 },
                 "gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "gas_used": {
                     "type": "integer"
@@ -1742,10 +1887,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "max_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "max_priority_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "nonce": {
                     "type": "integer"
@@ -1772,7 +1917,7 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "value": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         },
@@ -1862,6 +2007,41 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "token_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TransferModel": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "string"
+                },
+                "block_number": {
+                    "type": "string"
+                },
+                "block_timestamp": {
+                    "type": "string"
+                },
+                "from_address": {
+                    "type": "string"
+                },
+                "log_index": {
+                    "type": "integer"
+                },
+                "to_address": {
+                    "type": "string"
+                },
+                "token_address": {
+                    "type": "string"
+                },
+                "token_id": {
+                    "type": "string"
+                },
+                "token_type": {
+                    "type": "string"
+                },
+                "transaction_hash": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1298,6 +1298,151 @@
                     }
                 }
             }
+        },
+        "/{chainId}/transfers": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve token transfers by various filters",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "transfers"
+                ],
+                "summary": "Get token transfers",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Chain ID",
+                        "name": "chainId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Token types (erc721, erc1155, erc20)",
+                        "name": "token_type",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Token contract address",
+                        "name": "token_address",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Wallet address",
+                        "name": "wallet",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start block number",
+                        "name": "start_block",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End block number",
+                        "name": "end_block",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Start timestamp (RFC3339 format)",
+                        "name": "start_timestamp",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "End timestamp (RFC3339 format)",
+                        "name": "end_timestamp",
+                        "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "csv",
+                        "description": "Token IDs",
+                        "name": "token_id",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Transaction hash",
+                        "name": "transaction_hash",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 20,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/handlers.TransferModel"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1403,10 +1548,10 @@
                     "type": "string"
                 },
                 "gas_limit": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "gas_used": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "logs_bloom": {
                     "type": "string"
@@ -1543,7 +1688,7 @@
                     "type": "string"
                 },
                 "blob_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "blob_gas_used": {
                     "type": "integer"
@@ -1581,7 +1726,7 @@
                     ]
                 },
                 "effective_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "from_address": {
                     "type": "string"
@@ -1593,7 +1738,7 @@
                     "type": "integer"
                 },
                 "gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "gas_used": {
                     "type": "integer"
@@ -1605,10 +1750,10 @@
                     "type": "string"
                 },
                 "max_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "max_priority_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "nonce": {
                     "type": "integer"
@@ -1635,7 +1780,7 @@
                     "type": "string"
                 },
                 "value": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         },
@@ -1684,7 +1829,7 @@
                     "type": "string"
                 },
                 "blob_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "blob_gas_used": {
                     "type": "integer"
@@ -1711,7 +1856,7 @@
                     "type": "string"
                 },
                 "effective_gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "from_address": {
                     "type": "string"
@@ -1723,7 +1868,7 @@
                     "type": "integer"
                 },
                 "gas_price": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "gas_used": {
                     "type": "integer"
@@ -1735,10 +1880,10 @@
                     "type": "string"
                 },
                 "max_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "max_priority_fee_per_gas": {
-                    "type": "integer"
+                    "type": "string"
                 },
                 "nonce": {
                     "type": "integer"
@@ -1765,7 +1910,7 @@
                     "type": "string"
                 },
                 "value": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         },
@@ -1855,6 +2000,41 @@
                     "type": "string"
                 },
                 "token_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "handlers.TransferModel": {
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "string"
+                },
+                "block_number": {
+                    "type": "string"
+                },
+                "block_timestamp": {
+                    "type": "string"
+                },
+                "from_address": {
+                    "type": "string"
+                },
+                "log_index": {
+                    "type": "integer"
+                },
+                "to_address": {
+                    "type": "string"
+                },
+                "token_address": {
+                    "type": "string"
+                },
+                "token_id": {
+                    "type": "string"
+                },
+                "token_type": {
+                    "type": "string"
+                },
+                "transaction_hash": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -71,9 +71,9 @@ definitions:
       extra_data:
         type: string
       gas_limit:
-        type: integer
+        type: string
       gas_used:
-        type: integer
+        type: string
       logs_bloom:
         type: string
       miner:
@@ -162,7 +162,7 @@ definitions:
       access_list_json:
         type: string
       blob_gas_price:
-        type: integer
+        type: string
       blob_gas_used:
         type: integer
       block_hash:
@@ -186,7 +186,7 @@ definitions:
         - $ref: '#/definitions/common.DecodedTransactionDataModel'
         description: 'Deprecated: Use Decoded field instead'
       effective_gas_price:
-        type: integer
+        type: string
       from_address:
         type: string
       function_selector:
@@ -194,7 +194,7 @@ definitions:
       gas:
         type: integer
       gas_price:
-        type: integer
+        type: string
       gas_used:
         type: integer
       hash:
@@ -202,9 +202,9 @@ definitions:
       logs_bloom:
         type: string
       max_fee_per_gas:
-        type: integer
+        type: string
       max_priority_fee_per_gas:
-        type: integer
+        type: string
       nonce:
         type: integer
       r:
@@ -222,7 +222,7 @@ definitions:
       v:
         type: string
       value:
-        type: integer
+        type: string
     type: object
   common.LogModel:
     properties:
@@ -254,7 +254,7 @@ definitions:
       access_list_json:
         type: string
       blob_gas_price:
-        type: integer
+        type: string
       blob_gas_used:
         type: integer
       block_hash:
@@ -272,7 +272,7 @@ definitions:
       data:
         type: string
       effective_gas_price:
-        type: integer
+        type: string
       from_address:
         type: string
       function_selector:
@@ -280,7 +280,7 @@ definitions:
       gas:
         type: integer
       gas_price:
-        type: integer
+        type: string
       gas_used:
         type: integer
       hash:
@@ -288,9 +288,9 @@ definitions:
       logs_bloom:
         type: string
       max_fee_per_gas:
-        type: integer
+        type: string
       max_priority_fee_per_gas:
-        type: integer
+        type: string
       nonce:
         type: integer
       r:
@@ -308,7 +308,7 @@ definitions:
       v:
         type: string
       value:
-        type: integer
+        type: string
     type: object
   handlers.BalanceModel:
     properties:
@@ -370,6 +370,29 @@ definitions:
       token_id:
         type: string
       token_type:
+        type: string
+    type: object
+  handlers.TransferModel:
+    properties:
+      amount:
+        type: string
+      block_number:
+        type: string
+      block_timestamp:
+        type: string
+      from_address:
+        type: string
+      log_index:
+        type: integer
+      to_address:
+        type: string
+      token_address:
+        type: string
+      token_id:
+        type: string
+      token_type:
+        type: string
+      transaction_hash:
         type: string
     type: object
 info:
@@ -1157,6 +1180,99 @@ paths:
       summary: Get transactions by contract and signature
       tags:
       - transactions
+  /{chainId}/transfers:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve token transfers by various filters
+      parameters:
+      - description: Chain ID
+        in: path
+        name: chainId
+        required: true
+        type: string
+      - collectionFormat: csv
+        description: Token types (erc721, erc1155, erc20)
+        in: query
+        items:
+          type: string
+        name: token_type
+        type: array
+      - description: Token contract address
+        in: query
+        name: token_address
+        type: string
+      - description: Wallet address
+        in: query
+        name: wallet
+        type: string
+      - description: Start block number
+        in: query
+        name: start_block
+        type: string
+      - description: End block number
+        in: query
+        name: end_block
+        type: string
+      - description: Start timestamp (RFC3339 format)
+        in: query
+        name: start_timestamp
+        type: string
+      - description: End timestamp (RFC3339 format)
+        in: query
+        name: end_timestamp
+        type: string
+      - collectionFormat: csv
+        description: Token IDs
+        in: query
+        items:
+          type: string
+        name: token_id
+        type: array
+      - description: Transaction hash
+        in: query
+        name: transaction_hash
+        type: string
+      - description: Page number for pagination
+        in: query
+        name: page
+        type: integer
+      - default: 20
+        description: Number of items per page
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.QueryResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/handlers.TransferModel'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      security:
+      - BasicAuth: []
+      summary: Get token transfers
+      tags:
+      - transfers
   /search/:input:
     get:
       consumes:

--- a/internal/common/block.go
+++ b/internal/common/block.go
@@ -52,8 +52,8 @@ type BlockModel struct {
 	Difficulty       string `json:"difficulty"`
 	TotalDifficulty  string `json:"total_difficulty"`
 	TransactionCount uint64 `json:"transaction_count"`
-	GasLimit         uint64 `json:"gas_limit"`
-	GasUsed          uint64 `json:"gas_used"`
+	GasLimit         string `json:"gas_limit"`
+	GasUsed          string `json:"gas_used"`
 	WithdrawalsRoot  string `json:"withdrawals_root"`
 	BaseFeePerGas    uint64 `json:"base_fee_per_gas"`
 }
@@ -93,8 +93,8 @@ func (b *Block) Serialize() BlockModel {
 		Difficulty:       b.Difficulty.String(),
 		TotalDifficulty:  b.TotalDifficulty.String(),
 		TransactionCount: b.TransactionCount,
-		GasLimit:         b.GasLimit.Uint64(),
-		GasUsed:          b.GasUsed.Uint64(),
+		GasLimit:         b.GasLimit.String(),
+		GasUsed:          b.GasUsed.String(),
 		WithdrawalsRoot:  b.WithdrawalsRoot,
 		BaseFeePerGas:    b.BaseFeePerGas,
 	}

--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -67,13 +67,13 @@ type TransactionModel struct {
 	TransactionIndex     uint64  `json:"transaction_index"`
 	FromAddress          string  `json:"from_address"`
 	ToAddress            string  `json:"to_address"`
-	Value                uint64  `json:"value"`
+	Value                string  `json:"value"`
 	Gas                  uint64  `json:"gas"`
-	GasPrice             uint64  `json:"gas_price"`
+	GasPrice             string  `json:"gas_price"`
 	Data                 string  `json:"data"`
 	FunctionSelector     string  `json:"function_selector"`
-	MaxFeePerGas         uint64  `json:"max_fee_per_gas"`
-	MaxPriorityFeePerGas uint64  `json:"max_priority_fee_per_gas"`
+	MaxFeePerGas         string  `json:"max_fee_per_gas"`
+	MaxPriorityFeePerGas string  `json:"max_priority_fee_per_gas"`
 	TransactionType      uint8   `json:"transaction_type"`
 	R                    string  `json:"r"`
 	S                    string  `json:"s"`
@@ -82,9 +82,9 @@ type TransactionModel struct {
 	ContractAddress      *string `json:"contract_address"`
 	GasUsed              *uint64 `json:"gas_used"`
 	CumulativeGasUsed    *uint64 `json:"cumulative_gas_used"`
-	EffectiveGasPrice    *uint64 `json:"effective_gas_price"`
+	EffectiveGasPrice    *string `json:"effective_gas_price"`
 	BlobGasUsed          *uint64 `json:"blob_gas_used"`
-	BlobGasPrice         *uint64 `json:"blob_gas_price"`
+	BlobGasPrice         *string `json:"blob_gas_price"`
 	LogsBloom            *string `json:"logs_bloom"`
 	Status               *uint64 `json:"status"`
 }
@@ -182,13 +182,13 @@ func (t *Transaction) Serialize() TransactionModel {
 		TransactionIndex:     t.TransactionIndex,
 		FromAddress:          t.FromAddress,
 		ToAddress:            t.ToAddress,
-		Value:                t.Value.Uint64(),
+		Value:                t.Value.String(),
 		Gas:                  t.Gas,
-		GasPrice:             t.GasPrice.Uint64(),
+		GasPrice:             t.GasPrice.String(),
 		Data:                 t.Data,
 		FunctionSelector:     t.FunctionSelector,
-		MaxFeePerGas:         t.MaxFeePerGas.Uint64(),
-		MaxPriorityFeePerGas: t.MaxPriorityFeePerGas.Uint64(),
+		MaxFeePerGas:         t.MaxFeePerGas.String(),
+		MaxPriorityFeePerGas: t.MaxPriorityFeePerGas.String(),
 		TransactionType:      t.TransactionType,
 		R:                    t.R.String(),
 		S:                    t.S.String(),
@@ -197,19 +197,19 @@ func (t *Transaction) Serialize() TransactionModel {
 		ContractAddress:      t.ContractAddress,
 		GasUsed:              t.GasUsed,
 		CumulativeGasUsed:    t.CumulativeGasUsed,
-		EffectiveGasPrice: func() *uint64 {
+		EffectiveGasPrice: func() *string {
 			if t.EffectiveGasPrice == nil {
 				return nil
 			}
-			v := t.EffectiveGasPrice.Uint64()
+			v := t.EffectiveGasPrice.String()
 			return &v
 		}(),
 		BlobGasUsed: t.BlobGasUsed,
-		BlobGasPrice: func() *uint64 {
+		BlobGasPrice: func() *string {
 			if t.BlobGasPrice == nil {
 				return nil
 			}
-			v := t.BlobGasPrice.Uint64()
+			v := t.BlobGasPrice.String()
 			return &v
 		}(),
 		LogsBloom: t.LogsBloom,


### PR DESCRIPTION
### TL;DR

Updated numeric field types to strings for better precision and updated openapi schema

### What changed?

- Generated openapi for a new API endpoint `/{chainId}/transfers` for retrieving token transfers with various filtering options
- Added a new `TransferModel` definition to support the token transfers endpoint
- Changed several numeric field types from `integer` to `string` in API models to better handle large numbers:
  - In `BlockModel`: `gas_limit` and `gas_used`
  - In `TransactionModel`: `value`, `gas_price`, `max_fee_per_gas`, `max_priority_fee_per_gas`, `effective_gas_price`, and `blob_gas_price`

### How to test?

1. Make a GET request to the new endpoint `/{chainId}/transfers` with appropriate filters
2. Verify the response contains token transfer data in the expected format
3. Check that numeric values are properly returned as strings without precision loss
4. Test various filter combinations (token type, address, block range, etc.)

### Why make this change?

- The new transfers endpoint provides a dedicated way to query token transfer events, making it easier for clients to track token movements
- Converting numeric fields to strings prevents precision loss when dealing with large numbers (like gas prices and token values) that can exceed JavaScript's safe integer limits

GitHub Copilot: I'll help you create a pull request description for this change.