### PR TITLE
get wallet transcations endpoint

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -72,6 +72,7 @@ func RunApi(cmd *cobra.Command, args []string) {
 		// wildcard queries
 		root.GET("/transactions", handlers.GetTransactions)
 		root.GET("/events", handlers.GetLogs)
+		root.GET("/wallet-transactions/:wallet_address", handlers.GetWalletTransactions)
 
 		// contract scoped queries
 		root.GET("/transactions/:to", handlers.GetTransactionsByContract)

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -178,6 +178,8 @@ var allowedFunctions = map[string]struct{}{
 	"todatetime":           {},
 	"concat":               {},
 	"in":                   {},
+	"and":                  {},
+	"or":                   {},
 }
 
 var disallowedPatterns = []string{

--- a/internal/handlers/transactions_handlers.go
+++ b/internal/handlers/transactions_handlers.go
@@ -37,6 +37,31 @@ func GetTransactions(c *gin.Context) {
 	handleTransactionsRequest(c)
 }
 
+// @Summary Get wallet transactions
+// @Description Retrieve all incoming and outgoing transactions for a specific wallet address
+// @Tags wallet
+// @Accept json
+// @Produce json
+// @Security BasicAuth
+// @Param chainId path string true "Chain ID"
+// @Param wallet_address path string true "Wallet address"
+// @Param filter query string false "Filter parameters"
+// @Param group_by query string false "Field to group results by"
+// @Param sort_by query string false "Field to sort results by"
+// @Param sort_order query string false "Sort order (asc or desc)"
+// @Param page query int false "Page number for pagination"
+// @Param limit query int false "Number of items per page" default(5)
+// @Param force_consistent_data query bool false "Force consistent data at the expense of query speed"
+// @Param decode query bool false "Decode transaction data"
+// @Success 200 {object} api.QueryResponse{data=[]common.DecodedTransactionModel}
+// @Failure 400 {object} api.Error
+// @Failure 401 {object} api.Error
+// @Failure 500 {object} api.Error
+// @Router /{chainId}/wallet-transactions [get]
+func GetWalletTransactions(c *gin.Context) {
+	handleTransactionsRequest(c)
+}
+
 // @Summary Get transactions by contract
 // @Description Retrieve transactions for a specific contract
 // @Tags transactions
@@ -97,7 +122,7 @@ func handleTransactionsRequest(c *gin.Context) {
 
 	contractAddress := c.Param("to")
 	signature := c.Param("signature")
-
+	walletAddress := c.Param("wallet_address")
 	queryParams, err := api.ParseQueryParams(c.Request)
 	if err != nil {
 		api.BadRequestErrorHandler(c, err)
@@ -125,6 +150,7 @@ func handleTransactionsRequest(c *gin.Context) {
 	qf := storage.QueryFilter{
 		FilterParams:        queryParams.FilterParams,
 		ContractAddress:     contractAddress,
+		WalletAddress:       walletAddress,
 		Signature:           signatureHash,
 		ChainId:             chainId,
 		SortBy:              queryParams.SortBy,

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -469,6 +469,10 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 	if contractAddressClause != "" {
 		whereClauses = append(whereClauses, contractAddressClause)
 	}
+	walletAddressClause := createWalletAddressClause(table, qf.WalletAddress)
+	if walletAddressClause != "" {
+		whereClauses = append(whereClauses, walletAddressClause)
+	}
 	fromAddressClause := createFromAddressClause(table, qf.FromAddress)
 	if fromAddressClause != "" {
 		whereClauses = append(whereClauses, fromAddressClause)
@@ -594,6 +598,10 @@ func (c *ClickHouseConnector) buildQuery(table, columns string, qf QueryFilter) 
 	if contractAddressClause != "" {
 		whereClauses = append(whereClauses, contractAddressClause)
 	}
+	walletAddressClause := createWalletAddressClause(table, qf.WalletAddress)
+	if walletAddressClause != "" {
+		whereClauses = append(whereClauses, walletAddressClause)
+	}
 	fromAddressClause := createFromAddressClause(table, qf.FromAddress)
 	if fromAddressClause != "" {
 		whereClauses = append(whereClauses, fromAddressClause)
@@ -666,6 +674,14 @@ func createContractAddressClause(table, contractAddress string) string {
 		}
 	}
 	return ""
+}
+
+func createWalletAddressClause(table, walletAddress string) string {
+	walletAddress = strings.ToLower(walletAddress)
+	if table != "transactions" {
+		return ""
+	}
+	return fmt.Sprintf("(from_address = '%s' OR to_address = '%s')", walletAddress, walletAddress)
 }
 
 func createFromAddressClause(table, fromAddress string) string {

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -21,6 +21,7 @@ type QueryFilter struct {
 	Aggregates          []string // e.g., ["COUNT(*) AS count", "SUM(amount) AS total_amount"]
 	FromAddress         string
 	ContractAddress     string
+	WalletAddress       string
 	Signature           string
 	ForceConsistentData bool
 }


### PR DESCRIPTION
### TL;DR

Added a new API endpoint to retrieve all transactions (incoming and outgoing) for a specific wallet address.

### What changed?

- Added a new `/wallet-transactions` endpoint in the API router
- Created a new handler function `GetWalletTransactions` with appropriate Swagger documentation
- Implemented wallet address filtering in the query builder by adding `WalletAddress` field to the `QueryFilter` struct
- Added a new helper function `createWalletAddressClause` that filters transactions where the wallet is either the sender or receiver

### How to test?

1. Make a GET request to `/{chainId}/wallet-transactions?wallet_address=0x...` with a valid wallet address
2. Verify that the response includes both incoming and outgoing transactions for the specified wallet
3. Test with additional query parameters like pagination, sorting, and filtering

### Why make this change?

This endpoint provides a convenient way to retrieve all transactions associated with a specific wallet address, which is a common requirement for wallet applications and blockchain explorers. Previously, users would need to make separate queries for incoming and outgoing transactions or implement custom filtering logic.