### PR TITLE
fix: transactions query

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -678,7 +678,7 @@ func createContractAddressClause(table, contractAddress string) string {
 
 func createWalletAddressClause(table, walletAddress string) string {
 	walletAddress = strings.ToLower(walletAddress)
-	if table != "transactions" {
+	if table != "transactions" || walletAddress == "" {
 		return ""
 	}
 	return fmt.Sprintf("(from_address = '%s' OR to_address = '%s')", walletAddress, walletAddress)


### PR DESCRIPTION
### TL;DR

Fixed wallet address filtering in ClickHouse queries to handle empty wallet addresses.

### What changed?

Modified the `createWalletAddressClause` function in `internal/storage/clickhouse.go` to return an empty string when the wallet address is empty, preventing invalid SQL clauses from being generated.

### How to test?

1. Make a query to the API that would normally filter by wallet address, but provide an empty wallet address
2. Verify that the query executes successfully without SQL errors
3. Confirm that results are returned without wallet address filtering applied

### Why make this change?

When an empty wallet address was provided to the query builder, it would generate an invalid SQL clause like `(from_address = '' OR to_address = '')`. This change prevents SQL errors by not adding the wallet address filter when the address is empty, making the API more robust when handling optional parameters.