### PR TITLE
fix: offset from paging

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -1604,7 +1604,7 @@ func (c *ClickHouseConnector) GetTokenBalances(qf BalancesQueryFilter, fields ..
 
 	// Add limit clause
 	if qf.Page > 0 && qf.Limit > 0 {
-		offset := (qf.Page - 1) * qf.Limit
+		offset := qf.Page * qf.Limit
 		query += fmt.Sprintf(" LIMIT %d OFFSET %d", qf.Limit, offset)
 	} else if qf.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", qf.Limit)


### PR DESCRIPTION
### TL;DR

Fixed pagination offset calculation in token balances query.

### What changed?

Modified the offset calculation in the `GetTokenBalances` method to use `qf.Page * qf.Limit` instead of `(qf.Page - 1) * qf.Limit`. This changes how pagination works when retrieving token balances from the ClickHouse database.

### How to test?

1. Query token balances with pagination parameters (page > 0, limit > 0)
2. Verify that the correct records are returned for each page
3. Check that there is no overlap or gap between consecutive pages

### Why make this change?

The previous calculation assumed page numbers started at 1, but params in insight-service use pages starting with `0`. This fix ensures that the correct offset is calculated when paginating through token balances, preventing duplicate records or skipped entries when navigating through pages.