### PR TITLE
remove deprecated fields

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1450,6 +1450,132 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/{chainId}/wallet-transactions": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve all incoming and outgoing transactions for a specific wallet address",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "wallet"
+                ],
+                "summary": "Get wallet transactions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Chain ID",
+                        "name": "chainId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Wallet address",
+                        "name": "wallet_address",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter parameters",
+                        "name": "filter",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field to group results by",
+                        "name": "group_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field to sort results by",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "sort_order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Force consistent data at the expense of query speed",
+                        "name": "force_consistent_data",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Decode transaction data",
+                        "name": "decode",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/common.DecodedTransactionModel"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1604,17 +1730,11 @@ const docTemplate = `{
         "common.DecodedLogDataModel": {
             "type": "object",
             "properties": {
-                "indexedParams": {
-                    "type": "object"
-                },
                 "indexed_params": {
                     "type": "object"
                 },
                 "name": {
                     "type": "string"
-                },
-                "nonIndexedParams": {
-                    "type": "object"
                 },
                 "non_indexed_params": {
                     "type": "object"
@@ -1647,14 +1767,6 @@ const docTemplate = `{
                 },
                 "decoded": {
                     "$ref": "#/definitions/common.DecodedLogDataModel"
-                },
-                "decodedData": {
-                    "description": "Deprecated: Use Decoded field instead",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/common.DecodedLogDataModel"
-                        }
-                    ]
                 },
                 "log_index": {
                     "type": "integer"
@@ -1723,14 +1835,6 @@ const docTemplate = `{
                 },
                 "decoded": {
                     "$ref": "#/definitions/common.DecodedTransactionDataModel"
-                },
-                "decodedData": {
-                    "description": "Deprecated: Use Decoded field instead",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/common.DecodedTransactionDataModel"
-                        }
-                    ]
                 },
                 "effective_gas_price": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1443,6 +1443,132 @@
                     }
                 }
             }
+        },
+        "/{chainId}/wallet-transactions": {
+            "get": {
+                "security": [
+                    {
+                        "BasicAuth": []
+                    }
+                ],
+                "description": "Retrieve all incoming and outgoing transactions for a specific wallet address",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "wallet"
+                ],
+                "summary": "Get wallet transactions",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Chain ID",
+                        "name": "chainId",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Wallet address",
+                        "name": "wallet_address",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Filter parameters",
+                        "name": "filter",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field to group results by",
+                        "name": "group_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Field to sort results by",
+                        "name": "sort_by",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Sort order (asc or desc)",
+                        "name": "sort_order",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number for pagination",
+                        "name": "page",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "default": 5,
+                        "description": "Number of items per page",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Force consistent data at the expense of query speed",
+                        "name": "force_consistent_data",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Decode transaction data",
+                        "name": "decode",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/api.QueryResponse"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "$ref": "#/definitions/common.DecodedTransactionModel"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/api.Error"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -1597,17 +1723,11 @@
         "common.DecodedLogDataModel": {
             "type": "object",
             "properties": {
-                "indexedParams": {
-                    "type": "object"
-                },
                 "indexed_params": {
                     "type": "object"
                 },
                 "name": {
                     "type": "string"
-                },
-                "nonIndexedParams": {
-                    "type": "object"
                 },
                 "non_indexed_params": {
                     "type": "object"
@@ -1640,14 +1760,6 @@
                 },
                 "decoded": {
                     "$ref": "#/definitions/common.DecodedLogDataModel"
-                },
-                "decodedData": {
-                    "description": "Deprecated: Use Decoded field instead",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/common.DecodedLogDataModel"
-                        }
-                    ]
                 },
                 "log_index": {
                     "type": "integer"
@@ -1716,14 +1828,6 @@
                 },
                 "decoded": {
                     "$ref": "#/definitions/common.DecodedTransactionDataModel"
-                },
-                "decodedData": {
-                    "description": "Deprecated: Use Decoded field instead",
-                    "allOf": [
-                        {
-                            "$ref": "#/definitions/common.DecodedTransactionDataModel"
-                        }
-                    ]
                 },
                 "effective_gas_price": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -105,13 +105,9 @@ definitions:
     properties:
       indexed_params:
         type: object
-      indexedParams:
-        type: object
       name:
         type: string
       non_indexed_params:
-        type: object
-      nonIndexedParams:
         type: object
       signature:
         type: string
@@ -132,10 +128,6 @@ definitions:
         type: string
       decoded:
         $ref: '#/definitions/common.DecodedLogDataModel'
-      decodedData:
-        allOf:
-        - $ref: '#/definitions/common.DecodedLogDataModel'
-        description: 'Deprecated: Use Decoded field instead'
       log_index:
         type: integer
       topics:
@@ -181,10 +173,6 @@ definitions:
         type: string
       decoded:
         $ref: '#/definitions/common.DecodedTransactionDataModel'
-      decodedData:
-        allOf:
-        - $ref: '#/definitions/common.DecodedTransactionDataModel'
-        description: 'Deprecated: Use Decoded field instead'
       effective_gas_price:
         type: string
       from_address:
@@ -1273,6 +1261,87 @@ paths:
       summary: Get token transfers
       tags:
       - transfers
+  /{chainId}/wallet-transactions:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve all incoming and outgoing transactions for a specific
+        wallet address
+      parameters:
+      - description: Chain ID
+        in: path
+        name: chainId
+        required: true
+        type: string
+      - description: Wallet address
+        in: path
+        name: wallet_address
+        required: true
+        type: string
+      - description: Filter parameters
+        in: query
+        name: filter
+        type: string
+      - description: Field to group results by
+        in: query
+        name: group_by
+        type: string
+      - description: Field to sort results by
+        in: query
+        name: sort_by
+        type: string
+      - description: Sort order (asc or desc)
+        in: query
+        name: sort_order
+        type: string
+      - description: Page number for pagination
+        in: query
+        name: page
+        type: integer
+      - default: 5
+        description: Number of items per page
+        in: query
+        name: limit
+        type: integer
+      - description: Force consistent data at the expense of query speed
+        in: query
+        name: force_consistent_data
+        type: boolean
+      - description: Decode transaction data
+        in: query
+        name: decode
+        type: boolean
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/api.QueryResponse'
+            - properties:
+                data:
+                  items:
+                    $ref: '#/definitions/common.DecodedTransactionModel'
+                  type: array
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/api.Error'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/api.Error'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/api.Error'
+      security:
+      - BasicAuth: []
+      summary: Get wallet transactions
+      tags:
+      - wallet
   /search/:input:
     get:
       consumes:

--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -58,18 +58,15 @@ type LogModel struct {
 }
 
 type DecodedLogDataModel struct {
-	Name                       string                 `json:"name"`
-	Signature                  string                 `json:"signature"`
-	IndexedParamsDeprecated    map[string]interface{} `json:"indexedParams" swaggertype:"object" deprecated:"true"`
-	IndexedParams              map[string]interface{} `json:"indexed_params" swaggertype:"object"`
-	NonIndexedParamsDeprecated map[string]interface{} `json:"nonIndexedParams" swaggertype:"object" deprecated:"true"`
-	NonIndexedParams           map[string]interface{} `json:"non_indexed_params" swaggertype:"object"`
+	Name             string                 `json:"name"`
+	Signature        string                 `json:"signature"`
+	IndexedParams    map[string]interface{} `json:"indexed_params" swaggertype:"object"`
+	NonIndexedParams map[string]interface{} `json:"non_indexed_params" swaggertype:"object"`
 }
 
 type DecodedLogModel struct {
 	LogModel
-	Decoded     DecodedLogDataModel `json:"decoded"`
-	DecodedData DecodedLogDataModel `json:"decodedData" deprecated:"true"` // Deprecated: Use Decoded field instead
+	Decoded DecodedLogDataModel `json:"decoded"`
 }
 
 type RawLogs = []map[string]interface{}
@@ -252,17 +249,13 @@ func (l *Log) Serialize() LogModel {
 }
 
 func (l *DecodedLog) Serialize() DecodedLogModel {
-	decodedData := DecodedLogDataModel{
-		Name:                       l.Decoded.Name,
-		Signature:                  l.Decoded.Signature,
-		IndexedParams:              l.Decoded.IndexedParams,
-		IndexedParamsDeprecated:    l.Decoded.IndexedParams,
-		NonIndexedParams:           l.Decoded.NonIndexedParams,
-		NonIndexedParamsDeprecated: l.Decoded.NonIndexedParams,
-	}
 	return DecodedLogModel{
-		LogModel:    l.Log.Serialize(),
-		Decoded:     decodedData,
-		DecodedData: decodedData,
+		LogModel: l.Log.Serialize(),
+		Decoded: DecodedLogDataModel{
+			Name:             l.Decoded.Name,
+			Signature:        l.Decoded.Signature,
+			IndexedParams:    l.Decoded.IndexedParams,
+			NonIndexedParams: l.Decoded.NonIndexedParams,
+		},
 	}
 }

--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -97,8 +97,7 @@ type DecodedTransactionDataModel struct {
 
 type DecodedTransactionModel struct {
 	TransactionModel
-	Decoded     DecodedTransactionDataModel `json:"decoded"`
-	DecodedData DecodedTransactionDataModel `json:"decodedData" deprecated:"true"` // Deprecated: Use Decoded field instead
+	Decoded DecodedTransactionDataModel `json:"decoded"`
 }
 
 func DecodeTransactions(chainId string, txs []Transaction) []*DecodedTransaction {
@@ -218,14 +217,12 @@ func (t *Transaction) Serialize() TransactionModel {
 }
 
 func (t *DecodedTransaction) Serialize() DecodedTransactionModel {
-	decodedData := DecodedTransactionDataModel{
-		Name:      t.Decoded.Name,
-		Signature: t.Decoded.Signature,
-		Inputs:    t.Decoded.Inputs,
-	}
 	return DecodedTransactionModel{
 		TransactionModel: t.Transaction.Serialize(),
-		Decoded:          decodedData,
-		DecodedData:      decodedData,
+		Decoded: DecodedTransactionDataModel{
+			Name:      t.Decoded.Name,
+			Signature: t.Decoded.Signature,
+			Inputs:    t.Decoded.Inputs,
+		},
 	}
 }


### PR DESCRIPTION
### TL;DR

Removed deprecated fields from transaction and log models.

### What changed?

- Removed deprecated fields from transaction and log models:
  - Removed `decodedData` field (replaced by `decoded`)
  - Removed `indexedParams` and `nonIndexedParams` (replaced by `indexed_params` and `non_indexed_params`)
- Updated Swagger documentation to reflect these changes

### How to test?

Verify the response contains transaction data in the updated format without deprecated fields

### Why make this change?

This improves API consistency and reduces response payload size by eliminating duplicate data that was previously included for backward compatibility.