### PR TITLE
make max open connections configurable for ch

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -82,6 +82,7 @@ type ClickhouseConfig struct {
 	AsyncInsert      bool                           `mapstructure:"asyncInsert"`
 	MaxRowsPerInsert int                            `mapstructure:"maxRowsPerInsert"`
 	ChainBasedConfig map[string]TableOverrideConfig `mapstructure:"chainBasedConfig"`
+	MaxOpenConns     int                            `mapstructure:"maxOpenConns"`
 }
 
 type MemoryConfig struct {

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -82,7 +82,7 @@ func connectDB(cfg *config.ClickhouseConfig) (clickhouse.Conn, error) {
 		return nil, fmt.Errorf("invalid CLICKHOUSE_PORT: %d", port)
 	}
 
-	conn, err := clickhouse.Open(&clickhouse.Options{
+	options := &clickhouse.Options{
 		Addr:     []string{fmt.Sprintf("%s:%d", cfg.Host, port)},
 		Protocol: clickhouse.Native,
 		TLS: func() *tls.Config {
@@ -107,7 +107,12 @@ func connectDB(cfg *config.ClickhouseConfig) (clickhouse.Conn, error) {
 			}
 			return settings
 		}(),
-	})
+	}
+	if cfg.MaxOpenConns > 0 {
+		options.MaxOpenConns = cfg.MaxOpenConns
+	}
+
+	conn, err := clickhouse.Open(options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### TL;DR

Added support for configuring the maximum number of open connections to Clickhouse.

### What changed?

- Added a new `MaxOpenConns` field to the `ClickhouseConfig` struct in `configs/config.go`
- Modified the Clickhouse connection setup in `internal/storage/clickhouse.go` to use the configured `MaxOpenConns` value when it's greater than 0

### How to test?

1. Set the `maxOpenConns` parameter in your Clickhouse configuration
2. Verify that the connection pool respects this limit under load
3. Monitor Clickhouse server connection metrics to confirm the limit is enforced

### Why make this change?

This change allows for better control over connection pooling to Clickhouse, which can help prevent connection exhaustion under high load. By limiting the maximum number of open connections, we can ensure the application doesn't overwhelm the database server with too many concurrent connections, improving stability and resource utilization.