### PR TITLE
add blob fields to transactions

### DIFF
--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -28,6 +28,8 @@ type Transaction struct {
 	FunctionSelector     string    `json:"function_selector" ch:"function_selector"`
 	MaxFeePerGas         *big.Int  `json:"max_fee_per_gas" ch:"max_fee_per_gas" swaggertype:"string"`
 	MaxPriorityFeePerGas *big.Int  `json:"max_priority_fee_per_gas" ch:"max_priority_fee_per_gas" swaggertype:"string"`
+	MaxFeePerBlobGas     *big.Int  `json:"max_fee_per_blob_gas" ch:"max_fee_per_blob_gas" swaggertype:"string"`
+	BlobVersionedHashes  []string  `json:"blob_versioned_hashes" ch:"blob_versioned_hashes"`
 	TransactionType      uint8     `json:"transaction_type" ch:"transaction_type"`
 	R                    *big.Int  `json:"r" ch:"r" swaggertype:"string"`
 	S                    *big.Int  `json:"s" ch:"s" swaggertype:"string"`
@@ -58,35 +60,37 @@ type DecodedTransaction struct {
 
 // TransactionModel represents a simplified Transaction structure for Swagger documentation
 type TransactionModel struct {
-	ChainId              string  `json:"chain_id"`
-	Hash                 string  `json:"hash"`
-	Nonce                uint64  `json:"nonce"`
-	BlockHash            string  `json:"block_hash"`
-	BlockNumber          uint64  `json:"block_number"`
-	BlockTimestamp       uint64  `json:"block_timestamp"`
-	TransactionIndex     uint64  `json:"transaction_index"`
-	FromAddress          string  `json:"from_address"`
-	ToAddress            string  `json:"to_address"`
-	Value                string  `json:"value"`
-	Gas                  uint64  `json:"gas"`
-	GasPrice             string  `json:"gas_price"`
-	Data                 string  `json:"data"`
-	FunctionSelector     string  `json:"function_selector"`
-	MaxFeePerGas         string  `json:"max_fee_per_gas"`
-	MaxPriorityFeePerGas string  `json:"max_priority_fee_per_gas"`
-	TransactionType      uint8   `json:"transaction_type"`
-	R                    string  `json:"r"`
-	S                    string  `json:"s"`
-	V                    string  `json:"v"`
-	AccessListJson       *string `json:"access_list_json"`
-	ContractAddress      *string `json:"contract_address"`
-	GasUsed              *uint64 `json:"gas_used"`
-	CumulativeGasUsed    *uint64 `json:"cumulative_gas_used"`
-	EffectiveGasPrice    *string `json:"effective_gas_price"`
-	BlobGasUsed          *uint64 `json:"blob_gas_used"`
-	BlobGasPrice         *string `json:"blob_gas_price"`
-	LogsBloom            *string `json:"logs_bloom"`
-	Status               *uint64 `json:"status"`
+	ChainId              string   `json:"chain_id"`
+	Hash                 string   `json:"hash"`
+	Nonce                uint64   `json:"nonce"`
+	BlockHash            string   `json:"block_hash"`
+	BlockNumber          uint64   `json:"block_number"`
+	BlockTimestamp       uint64   `json:"block_timestamp"`
+	TransactionIndex     uint64   `json:"transaction_index"`
+	FromAddress          string   `json:"from_address"`
+	ToAddress            string   `json:"to_address"`
+	Value                string   `json:"value"`
+	Gas                  uint64   `json:"gas"`
+	GasPrice             string   `json:"gas_price"`
+	Data                 string   `json:"data"`
+	FunctionSelector     string   `json:"function_selector"`
+	MaxFeePerGas         string   `json:"max_fee_per_gas"`
+	MaxPriorityFeePerGas string   `json:"max_priority_fee_per_gas"`
+	MaxFeePerBlobGas     *string  `json:"max_fee_per_blob_gas,omitempty"`
+	BlobVersionedHashes  []string `json:"blob_versioned_hashes,omitempty"`
+	TransactionType      uint8    `json:"transaction_type"`
+	R                    string   `json:"r"`
+	S                    string   `json:"s"`
+	V                    string   `json:"v"`
+	AccessListJson       *string  `json:"access_list_json"`
+	ContractAddress      *string  `json:"contract_address"`
+	GasUsed              *uint64  `json:"gas_used"`
+	CumulativeGasUsed    *uint64  `json:"cumulative_gas_used"`
+	EffectiveGasPrice    *string  `json:"effective_gas_price"`
+	BlobGasUsed          *uint64  `json:"blob_gas_used"`
+	BlobGasPrice         *string  `json:"blob_gas_price"`
+	LogsBloom            *string  `json:"logs_bloom"`
+	Status               *uint64  `json:"status"`
 }
 
 type DecodedTransactionDataModel struct {
@@ -188,14 +192,22 @@ func (t *Transaction) Serialize() TransactionModel {
 		FunctionSelector:     t.FunctionSelector,
 		MaxFeePerGas:         t.MaxFeePerGas.String(),
 		MaxPriorityFeePerGas: t.MaxPriorityFeePerGas.String(),
-		TransactionType:      t.TransactionType,
-		R:                    t.R.String(),
-		S:                    t.S.String(),
-		V:                    t.V.String(),
-		AccessListJson:       t.AccessListJson,
-		ContractAddress:      t.ContractAddress,
-		GasUsed:              t.GasUsed,
-		CumulativeGasUsed:    t.CumulativeGasUsed,
+		MaxFeePerBlobGas: func() *string {
+			if t.MaxFeePerBlobGas == nil {
+				return nil
+			}
+			v := t.MaxFeePerBlobGas.String()
+			return &v
+		}(),
+		BlobVersionedHashes: t.BlobVersionedHashes,
+		TransactionType:     t.TransactionType,
+		R:                   t.R.String(),
+		S:                   t.S.String(),
+		V:                   t.V.String(),
+		AccessListJson:      t.AccessListJson,
+		ContractAddress:     t.ContractAddress,
+		GasUsed:             t.GasUsed,
+		CumulativeGasUsed:   t.CumulativeGasUsed,
 		EffectiveGasPrice: func() *string {
 			if t.EffectiveGasPrice == nil {
 				return nil

--- a/internal/rpc/serializer.go
+++ b/internal/rpc/serializer.go
@@ -189,6 +189,8 @@ func serializeTransaction(chainId *big.Int, tx map[string]interface{}, blockTime
 		FunctionSelector:     ExtractFunctionSelector(interfaceToString(tx["input"])),
 		MaxFeePerGas:         hexToBigInt(tx["maxFeePerGas"]),
 		MaxPriorityFeePerGas: hexToBigInt(tx["maxPriorityFeePerGas"]),
+		MaxFeePerBlobGas:     hexToBigInt(tx["maxFeePerBlobGas"]),
+		BlobVersionedHashes:  interfaceToStringSlice(tx["blobVersionedHashes"]),
 		TransactionType:      uint8(hexToUint64(tx["type"])),
 		R:                    hexToBigInt(tx["r"]),
 		S:                    hexToBigInt(tx["s"]),
@@ -427,6 +429,28 @@ func interfaceToString(value interface{}) string {
 		return ""
 	}
 	return res
+}
+
+func interfaceToStringSlice(value interface{}) []string {
+	if value == nil {
+		return []string{}
+	}
+
+	// Handle []string case
+	if res, ok := value.([]string); ok {
+		return res
+	}
+
+	// Handle []interface{} case
+	if res, ok := value.([]interface{}); ok {
+		strings := make([]string, len(res))
+		for i, v := range res {
+			strings[i] = interfaceToString(v)
+		}
+		return strings
+	}
+
+	return []string{}
 }
 
 func interfaceToJsonString(value interface{}) string {

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -44,9 +44,9 @@ var defaultTransactionFields = []string{
 	"chain_id", "hash", "nonce", "block_hash", "block_number", "block_timestamp",
 	"transaction_index", "from_address", "to_address", "value", "gas", "gas_price",
 	"data", "function_selector", "max_fee_per_gas", "max_priority_fee_per_gas",
-	"transaction_type", "r", "s", "v", "access_list", "contract_address", "gas_used",
-	"cumulative_gas_used", "effective_gas_price", "blob_gas_used", "blob_gas_price",
-	"logs_bloom", "status",
+	"max_fee_per_blob_gas", "blob_versioned_hashes", "transaction_type", "r", "s", "v",
+	"access_list", "contract_address", "gas_used", "cumulative_gas_used",
+	"effective_gas_price", "blob_gas_used", "blob_gas_price", "logs_bloom", "status",
 }
 
 var defaultLogFields = []string{
@@ -194,7 +194,7 @@ func (c *ClickHouseConnector) insertTransactions(txs []common.Transaction, opt I
 	tableName := c.getTableName(txs[0].ChainId, "transactions")
 	columns := []string{
 		"chain_id", "hash", "nonce", "block_hash", "block_number", "block_timestamp", "transaction_index", "from_address", "to_address", "value", "gas",
-		"gas_price", "data", "function_selector", "max_fee_per_gas", "max_priority_fee_per_gas", "transaction_type", "r", "s", "v", "access_list",
+		"gas_price", "data", "function_selector", "max_fee_per_gas", "max_priority_fee_per_gas", "max_fee_per_blob_gas", "blob_versioned_hashes", "transaction_type", "r", "s", "v", "access_list",
 		"contract_address", "gas_used", "cumulative_gas_used", "effective_gas_price", "blob_gas_used", "blob_gas_price", "logs_bloom", "status", "sign",
 	}
 	if opt.AsDeleted {
@@ -230,6 +230,8 @@ func (c *ClickHouseConnector) insertTransactions(txs []common.Transaction, opt I
 				tx.FunctionSelector,
 				tx.MaxFeePerGas,
 				tx.MaxPriorityFeePerGas,
+				tx.MaxFeePerBlobGas,
+				tx.BlobVersionedHashes,
 				tx.TransactionType,
 				tx.R,
 				tx.S,

--- a/internal/tools/clickhouse_create_transactions_table.sql
+++ b/internal/tools/clickhouse_create_transactions_table.sql
@@ -15,6 +15,8 @@ CREATE TABLE IF NOT EXISTS transactions (
     `function_selector` FixedString(10),
     `max_fee_per_gas` UInt128,
     `max_priority_fee_per_gas` UInt128,
+    `max_fee_per_blob_gas` UInt256,
+    `blob_versioned_hashes` Array(String),
     `transaction_type` UInt8,
     `r` UInt256,
     `s` UInt256,


### PR DESCRIPTION
### TL;DR

Added support for EIP-4844 blob transaction fields in the transaction data model.

### What changed?

- Added two new fields to the `Transaction` struct:
  - `MaxFeePerBlobGas` - to store the maximum fee per blob gas
  - `BlobVersionedHashes` - to store the versioned hashes of the blobs

- Updated the `TransactionModel` struct to include these new fields

- Modified the transaction serialization logic to handle the new blob-related fields

- Updated the ClickHouse database schema and insertion logic to store the new fields

### How to test?

1. Process transactions from a network that supports EIP-4844 (like Ethereum mainnet post-Dencun upgrade)
2. Verify that blob transactions are correctly stored with their `MaxFeePerBlobGas` and `BlobVersionedHashes` values
3. Query the transactions table to confirm the new fields are populated for blob transactions

### Why make this change?

This change adds support for EIP-4844 (blob transactions) introduced in the Ethereum Dencun upgrade. Blob transactions include additional fields that need to be captured and stored in our system to maintain complete transaction data. Without these fields, we would be missing critical information about blob transactions, which are important for layer 2 rollups and other scaling solutions.