### PR TITLE
convert decoded big numbers to strings in api response

### DIFF
--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -252,13 +252,17 @@ func (l *Log) Serialize() LogModel {
 }
 
 func (l *DecodedLog) Serialize() DecodedLogModel {
+	// Convert big numbers to strings in both indexed and non-indexed parameters
+	indexedParams := ConvertBigNumbersToString(l.Decoded.IndexedParams).(map[string]interface{})
+	nonIndexedParams := ConvertBigNumbersToString(l.Decoded.NonIndexedParams).(map[string]interface{})
+
 	return DecodedLogModel{
 		LogModel: l.Log.Serialize(),
 		Decoded: DecodedLogDataModel{
 			Name:             l.Decoded.Name,
 			Signature:        l.Decoded.Signature,
-			IndexedParams:    l.Decoded.IndexedParams,
-			NonIndexedParams: l.Decoded.NonIndexedParams,
+			IndexedParams:    indexedParams,
+			NonIndexedParams: nonIndexedParams,
 		},
 	}
 }

--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -229,12 +229,15 @@ func (t *Transaction) Serialize() TransactionModel {
 }
 
 func (t *DecodedTransaction) Serialize() DecodedTransactionModel {
+	// Convert big numbers to strings in the decoded inputs
+	decodedInputs := ConvertBigNumbersToString(t.Decoded.Inputs).(map[string]interface{})
+
 	return DecodedTransactionModel{
 		TransactionModel: t.Transaction.Serialize(),
 		Decoded: DecodedTransactionDataModel{
 			Name:      t.Decoded.Name,
 			Signature: t.Decoded.Signature,
-			Inputs:    t.Decoded.Inputs,
+			Inputs:    decodedInputs,
 		},
 	}
 }


### PR DESCRIPTION
### TL;DR

Added support for converting big numbers to strings in decoded transaction and log data.

### What changed?

- Added a new utility function `ConvertBigNumbersToString` that recursively converts `*big.Int` and `big.Int` values to strings
- Updated the `Serialize` method for `DecodedLog` to convert big numbers to strings in both indexed and non-indexed parameters
- Updated the `Serialize` method for `DecodedTransaction` to convert big numbers to strings in decoded inputs
- Removed unused `StripPayload` function and related helper functions

### How to test?

1. Create a transaction or log that contains big numbers in its decoded data
2. Call the `Serialize` method on the decoded transaction or log
3. Verify that the big numbers are properly converted to strings in the output

### Why make this change?

Big numbers in decoded transaction and log data need to be converted to strings to ensure they can be properly serialized to JSON without precision loss. This is especially important for large numbers that exceed the range of standard JSON number types.