### PR TITLE
fix sign on insert

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -1264,7 +1264,7 @@ func (c *ClickHouseConnector) InsertBlockData(data []common.BlockData) error {
 			}
 
 			sign := int8(1)
-			if block.Sign != 1 {
+			if block.Sign == -1 {
 				sign = block.Sign
 			}
 			insertTimestamp := time.Now()


### PR DESCRIPTION
### TL;DR

Fixed a bug in the `InsertBlockData` function where negative block signs were not being properly handled.

### What changed?

Modified the condition in `InsertBlockData` that determines when to use the block's sign value. Previously, the code would only use the block's sign if it wasn't equal to 1, but now it specifically checks if the sign is -1. This ensures that only explicitly negative signs are treated differently.

### How to test?

1. Insert block data with different sign values (-1, 0, 1)
2. Verify that only blocks with sign = -1 are stored with a negative sign
3. Verify that blocks with sign = 0 are stored with the default sign value of 1

### Why make this change?

The previous implementation had a logic error where any sign value that wasn't 1 (including 0) would be used as-is. This could lead to incorrect sign values being stored in the database. The fix ensures that only explicitly negative signs (-1) are preserved, while all other values default to positive (1).