### PR TITLE
better logging in case of jsonrpc errors

### DIFF
--- a/internal/rpc/serializer.go
+++ b/internal/rpc/serializer.go
@@ -26,8 +26,8 @@ func SerializeFullBlocks(chainId *big.Int, blocks []RPCFetchBatchResult[common.R
 			BlockNumber: rawBlock.BlockNumber,
 		}
 		if rawBlock.Result == nil {
-			log.Warn().Msgf("Received a nil block result for block %s.", rawBlock.BlockNumber.String())
-			result.Error = fmt.Errorf("received a nil block result from RPC")
+			log.Warn().Err(rawBlock.Error).Msgf("Received a nil block result for block %s.", rawBlock.BlockNumber.String())
+			result.Error = fmt.Errorf("received a nil block result from RPC. %v", rawBlock.Error)
 			results = append(results, result)
 			continue
 		}


### PR DESCRIPTION
### TL;DR

Improved error logging for nil block results in the RPC serializer.

### What changed?

Enhanced the error handling in `SerializeFullBlocks` function by:
1. Including the original error from `rawBlock.Error` in the log message
2. Adding the original error details to the error message returned in the result

### How to test?

1. Trigger a scenario where a nil block result is returned from an RPC call
2. Verify that the logs now include the original error information
3. Confirm that the error message in the result contains the details from the original error

### Why make this change?

This change provides more detailed error information when nil block results are encountered, making it easier to diagnose issues with RPC calls. The previous implementation only logged that a nil result was received without including the underlying error details, which limited troubleshooting capabilities.