### PR TITLE
limit for aggregations

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -504,6 +504,14 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 		query += fmt.Sprintf(" ORDER BY %s %s", qf.SortBy, qf.SortOrder)
 	}
 
+	// Add limit clause
+	if qf.Page > 0 && qf.Limit > 0 {
+		offset := (qf.Page - 1) * qf.Limit
+		query += fmt.Sprintf(" LIMIT %d OFFSET %d", qf.Limit, offset)
+	} else if qf.Limit > 0 {
+		query += fmt.Sprintf(" LIMIT %d", qf.Limit)
+	}
+
 	if err := common.ValidateQuery(query); err != nil {
 		return QueryResult[interface{}]{}, err
 	}


### PR DESCRIPTION
### TL;DR

Added pagination support to the ClickHouse aggregation queries.

### What changed?

Added a LIMIT and OFFSET clause to the GetAggregations method in the ClickHouseConnector. The implementation:
- Adds LIMIT and OFFSET when both page and limit are specified
- Adds only LIMIT when just the limit is specified
- Calculates the correct offset based on page number and limit

### How to test?

1. Make a query to the API that uses the GetAggregations method with pagination parameters
2. Verify that the query returns the correct number of results based on the limit
3. Test with different page numbers to ensure proper pagination
4. Verify that queries without pagination parameters still work correctly

### Why make this change?

This change enables proper pagination for aggregation queries, which is essential for handling large result sets efficiently. Without pagination, large query results could cause performance issues or timeout errors. This implementation allows clients to request specific pages of results with a defined size limit.