### PR TITLE
add rpc function to fetch transactions by hashes

### DIFF
--- a/internal/common/transaction.go
+++ b/internal/common/transaction.go
@@ -11,6 +11,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
+type RawTransaction = map[string]interface{}
+
 type Transaction struct {
 	ChainId               *big.Int  `json:"chain_id" ch:"chain_id" swaggertype:"string"`
 	Hash                  string    `json:"hash" ch:"hash"`

--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -7,11 +7,11 @@ import (
 	"strings"
 )
 
-func BigIntSliceToChunks(values []*big.Int, chunkSize int) [][]*big.Int {
+func SliceToChunks[T any](values []T, chunkSize int) [][]T {
 	if chunkSize >= len(values) || chunkSize <= 0 {
-		return [][]*big.Int{values}
+		return [][]T{values}
 	}
-	var chunks [][]*big.Int
+	var chunks [][]T
 	for i := 0; i < len(values); i += chunkSize {
 		end := i + chunkSize
 		if end > len(values) {

--- a/internal/orchestrator/reorg_handler.go
+++ b/internal/orchestrator/reorg_handler.go
@@ -230,7 +230,7 @@ func (rh *ReorgHandler) getNewBlocksByNumber(blockHeaders []common.BlockHeader) 
 		blockNumbers = append(blockNumbers, header.Number)
 	}
 	blockCount := len(blockNumbers)
-	chunks := common.BigIntSliceToChunks(blockNumbers, rh.rpc.GetBlocksPerRequest().Blocks)
+	chunks := common.SliceToChunks(blockNumbers, rh.rpc.GetBlocksPerRequest().Blocks)
 
 	var wg sync.WaitGroup
 	resultsCh := make(chan []rpc.GetBlocksResult, len(chunks))

--- a/internal/rpc/params.go
+++ b/internal/rpc/params.go
@@ -10,6 +10,10 @@ func GetBlockWithTransactionsParams(blockNum *big.Int) []interface{} {
 	return []interface{}{hexutil.EncodeBig(blockNum), true}
 }
 
+func GetTransactionParams(txHash string) []interface{} {
+	return []interface{}{txHash}
+}
+
 func GetBlockWithoutTransactionsParams(blockNum *big.Int) []interface{} {
 	return []interface{}{hexutil.EncodeBig(blockNum), false}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -24,7 +24,7 @@ func NewWorker(rpc rpc.IRPCClient) *Worker {
 
 func (w *Worker) Run(blockNumbers []*big.Int) []rpc.GetFullBlockResult {
 	blockCount := len(blockNumbers)
-	chunks := common.BigIntSliceToChunks(blockNumbers, w.rpc.GetBlocksPerRequest().Blocks)
+	chunks := common.SliceToChunks(blockNumbers, w.rpc.GetBlocksPerRequest().Blocks)
 
 	var wg sync.WaitGroup
 	resultsCh := make(chan []rpc.GetFullBlockResult, len(chunks))

--- a/test/mocks/MockIRPCClient.go
+++ b/test/mocks/MockIRPCClient.go
@@ -24,6 +24,38 @@ func (_m *MockIRPCClient) EXPECT() *MockIRPCClient_Expecter {
 	return &MockIRPCClient_Expecter{mock: &_m.Mock}
 }
 
+// Close provides a mock function with no fields
+func (_m *MockIRPCClient) Close() {
+	_m.Called()
+}
+
+// MockIRPCClient_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
+type MockIRPCClient_Close_Call struct {
+	*mock.Call
+}
+
+// Close is a helper method to define mock.On call
+func (_e *MockIRPCClient_Expecter) Close() *MockIRPCClient_Close_Call {
+	return &MockIRPCClient_Close_Call{Call: _e.mock.On("Close")}
+}
+
+func (_c *MockIRPCClient_Close_Call) Run(run func()) *MockIRPCClient_Close_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockIRPCClient_Close_Call) Return() *MockIRPCClient_Close_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockIRPCClient_Close_Call) RunAndReturn(run func()) *MockIRPCClient_Close_Call {
+	_c.Run(run)
+	return _c
+}
+
 // GetBlocks provides a mock function with given fields: blockNumbers
 func (_m *MockIRPCClient) GetBlocks(blockNumbers []*big.Int) []rpc.GetBlocksResult {
 	ret := _m.Called(blockNumbers)
@@ -265,6 +297,54 @@ func (_c *MockIRPCClient_GetLatestBlockNumber_Call) Return(_a0 *big.Int, _a1 err
 }
 
 func (_c *MockIRPCClient_GetLatestBlockNumber_Call) RunAndReturn(run func() (*big.Int, error)) *MockIRPCClient_GetLatestBlockNumber_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetTransactions provides a mock function with given fields: txHashes
+func (_m *MockIRPCClient) GetTransactions(txHashes []string) []rpc.GetTransactionsResult {
+	ret := _m.Called(txHashes)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTransactions")
+	}
+
+	var r0 []rpc.GetTransactionsResult
+	if rf, ok := ret.Get(0).(func([]string) []rpc.GetTransactionsResult); ok {
+		r0 = rf(txHashes)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]rpc.GetTransactionsResult)
+		}
+	}
+
+	return r0
+}
+
+// MockIRPCClient_GetTransactions_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTransactions'
+type MockIRPCClient_GetTransactions_Call struct {
+	*mock.Call
+}
+
+// GetTransactions is a helper method to define mock.On call
+//   - txHashes []string
+func (_e *MockIRPCClient_Expecter) GetTransactions(txHashes interface{}) *MockIRPCClient_GetTransactions_Call {
+	return &MockIRPCClient_GetTransactions_Call{Call: _e.mock.On("GetTransactions", txHashes)}
+}
+
+func (_c *MockIRPCClient_GetTransactions_Call) Run(run func(txHashes []string)) *MockIRPCClient_GetTransactions_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].([]string))
+	})
+	return _c
+}
+
+func (_c *MockIRPCClient_GetTransactions_Call) Return(_a0 []rpc.GetTransactionsResult) *MockIRPCClient_GetTransactions_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockIRPCClient_GetTransactions_Call) RunAndReturn(run func([]string) []rpc.GetTransactionsResult) *MockIRPCClient_GetTransactions_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR

Added support for fetching transactions by hash through the RPC client.

### What changed?

- Added a new `RawTransaction` type alias in the common package
- Generalized the `RPCFetchBatch` function to `RPCFetchSingleBatch` to work with any key type, not just block numbers
- Added `GetTransactionParams` function to support transaction hash parameters
- Implemented `GetTransactions` method in the RPC client to fetch transactions by hash
- Added `SerializeTransactions` function to convert raw transaction data to the internal format
- Added `Close` method to the `IRPCClient` interface and updated the mock accordingly

### How to test?

1. Fetch transactions using the new method:
```go
client := rpc.NewClient(...)
transactions := client.GetTransactions([]string{"0x123...", "0x456..."})
```

2. Verify that transaction data is properly serialized and contains the expected fields
3. Test with both valid and invalid transaction hashes to ensure error handling works correctly

### Why make this change?

This change enables direct fetching of transactions by hash, which is useful for scenarios where we need to retrieve specific transactions without fetching entire blocks. This improves efficiency when only transaction data is needed and the containing block is not relevant.