### PR TITLE
pass context to rpc and worker

### DIFF
--- a/internal/orchestrator/chain_tracker.go
+++ b/internal/orchestrator/chain_tracker.go
@@ -35,7 +35,7 @@ func (ct *ChainTracker) Start(ctx context.Context) {
 			log.Info().Msg("Chain tracker shutting down")
 			return
 		case <-ticker.C:
-			latestBlockNumber, err := ct.rpc.GetLatestBlockNumber()
+			latestBlockNumber, err := ct.rpc.GetLatestBlockNumber(ctx)
 			if err != nil {
 				log.Error().Err(err).Msg("Error getting latest block number")
 				continue

--- a/internal/orchestrator/committer_test.go
+++ b/internal/orchestrator/committer_test.go
@@ -254,7 +254,7 @@ func TestGetSequentialBlockDataToCommit(t *testing.T) {
 		BlockNumbers: []*big.Int{big.NewInt(101), big.NewInt(102), big.NewInt(103)},
 	}).Return(blockData, nil)
 
-	result, err := committer.getSequentialBlockDataToCommit()
+	result, err := committer.getSequentialBlockDataToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -290,7 +290,7 @@ func TestGetSequentialBlockDataToCommitWithDuplicateBlocks(t *testing.T) {
 		BlockNumbers: []*big.Int{big.NewInt(101), big.NewInt(102), big.NewInt(103)},
 	}).Return(blockData, nil)
 
-	result, err := committer.getSequentialBlockDataToCommit()
+	result, err := committer.getSequentialBlockDataToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
@@ -320,7 +320,7 @@ func TestCommit(t *testing.T) {
 	mockMainStorage.EXPECT().InsertBlockData(blockData).Return(nil)
 	mockStagingStorage.EXPECT().DeleteStagingData(blockData).Return(nil)
 
-	err := committer.commit(blockData)
+	err := committer.commit(context.Background(), blockData)
 
 	assert.NoError(t, err)
 }
@@ -343,7 +343,7 @@ func TestHandleGap(t *testing.T) {
 	mockRPC.EXPECT().GetBlocksPerRequest().Return(rpc.BlocksPerRequestConfig{
 		Blocks: 5,
 	})
-	mockRPC.EXPECT().GetFullBlocks([]*big.Int{big.NewInt(100), big.NewInt(101), big.NewInt(102), big.NewInt(103), big.NewInt(104)}).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), []*big.Int{big.NewInt(100), big.NewInt(101), big.NewInt(102), big.NewInt(103), big.NewInt(104)}).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(100), Data: common.BlockData{Block: common.Block{Number: big.NewInt(100)}}},
 		{BlockNumber: big.NewInt(101), Data: common.BlockData{Block: common.Block{Number: big.NewInt(101)}}},
 		{BlockNumber: big.NewInt(102), Data: common.BlockData{Block: common.Block{Number: big.NewInt(102)}}},
@@ -352,7 +352,7 @@ func TestHandleGap(t *testing.T) {
 	})
 	mockStagingStorage.EXPECT().InsertStagingData(mock.Anything).Return(nil)
 
-	err := committer.handleGap(expectedStartBlockNumber, actualFirstBlock)
+	err := committer.handleGap(context.Background(), expectedStartBlockNumber, actualFirstBlock)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "first block number (105) in commit batch does not match expected (100)")
@@ -463,7 +463,7 @@ func TestHandleMissingStagingData(t *testing.T) {
 	mockRPC.EXPECT().GetBlocksPerRequest().Return(rpc.BlocksPerRequestConfig{
 		Blocks: 100,
 	})
-	mockRPC.EXPECT().GetFullBlocks([]*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)}).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)}).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(0), Data: common.BlockData{Block: common.Block{Number: big.NewInt(0)}}},
 		{BlockNumber: big.NewInt(1), Data: common.BlockData{Block: common.Block{Number: big.NewInt(1)}}},
 		{BlockNumber: big.NewInt(2), Data: common.BlockData{Block: common.Block{Number: big.NewInt(2)}}},
@@ -482,7 +482,7 @@ func TestHandleMissingStagingData(t *testing.T) {
 		BlockNumbers: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)},
 	}).Return(blockData, nil)
 
-	result, err := committer.getSequentialBlockDataToCommit()
+	result, err := committer.getSequentialBlockDataToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Nil(t, result)
@@ -509,7 +509,7 @@ func TestHandleMissingStagingDataIsPolledWithCorrectBatchSize(t *testing.T) {
 	mockRPC.EXPECT().GetBlocksPerRequest().Return(rpc.BlocksPerRequestConfig{
 		Blocks: 3,
 	})
-	mockRPC.EXPECT().GetFullBlocks([]*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)}).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2)}).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(0), Data: common.BlockData{Block: common.Block{Number: big.NewInt(0)}}},
 		{BlockNumber: big.NewInt(1), Data: common.BlockData{Block: common.Block{Number: big.NewInt(1)}}},
 		{BlockNumber: big.NewInt(2), Data: common.BlockData{Block: common.Block{Number: big.NewInt(2)}}},
@@ -526,7 +526,7 @@ func TestHandleMissingStagingDataIsPolledWithCorrectBatchSize(t *testing.T) {
 		BlockNumbers: []*big.Int{big.NewInt(0), big.NewInt(1), big.NewInt(2), big.NewInt(3), big.NewInt(4)},
 	}).Return(blockData, nil)
 
-	result, err := committer.getSequentialBlockDataToCommit()
+	result, err := committer.getSequentialBlockDataToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Nil(t, result)

--- a/internal/orchestrator/failure_recoverer.go
+++ b/internal/orchestrator/failure_recoverer.go
@@ -75,7 +75,7 @@ func (fr *FailureRecoverer) Start(ctx context.Context) {
 			// Trigger worker for recovery
 			log.Debug().Msgf("Triggering Failure Recoverer for blocks: %v", blocksToTrigger)
 			worker := worker.NewWorker(fr.rpc)
-			results := worker.Run(blocksToTrigger)
+			results := worker.Run(ctx, blocksToTrigger)
 			fr.handleWorkerResults(blockFailures, results)
 
 			// Track recovery activity

--- a/internal/orchestrator/reorg_handler_test.go
+++ b/internal/orchestrator/reorg_handler_test.go
@@ -240,14 +240,14 @@ func TestFindFirstReorgedBlockNumber(t *testing.T) {
 		{Number: big.NewInt(1), Hash: "hash1", ParentHash: "hash0"},
 	}
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(3), Data: common.Block{Hash: "hash3", ParentHash: "hash2"}},
 		{BlockNumber: big.NewInt(2), Data: common.Block{Hash: "hash2", ParentHash: "hash1"}},
 		{BlockNumber: big.NewInt(1), Data: common.Block{Hash: "hash1", ParentHash: "hash0"}},
 	})
 
 	reorgedBlockNumbers := []*big.Int{}
-	err := handler.findReorgedBlockNumbers(reversedBlockHeaders, &reorgedBlockNumbers)
+	err := handler.findReorgedBlockNumbers(context.Background(), reversedBlockHeaders, &reorgedBlockNumbers)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []*big.Int{big.NewInt(3)}, reorgedBlockNumbers)
@@ -274,14 +274,14 @@ func TestFindAllReorgedBlockNumbersWithLastBlockInSliceAsValid(t *testing.T) {
 		{Number: big.NewInt(1), Hash: "hash1", ParentHash: "hash0"},
 	}
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(3), Data: common.Block{Hash: "hash3", ParentHash: "hash2"}},
 		{BlockNumber: big.NewInt(2), Data: common.Block{Hash: "hash2", ParentHash: "hash1"}},
 		{BlockNumber: big.NewInt(1), Data: common.Block{Hash: "hash1", ParentHash: "hash0"}},
 	})
 
 	reorgedBlockNumbers := []*big.Int{}
-	err := handler.findReorgedBlockNumbers(reversedBlockHeaders, &reorgedBlockNumbers)
+	err := handler.findReorgedBlockNumbers(context.Background(), reversedBlockHeaders, &reorgedBlockNumbers)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []*big.Int{big.NewInt(3), big.NewInt(2)}, reorgedBlockNumbers)
@@ -305,7 +305,7 @@ func TestFindManyReorgsInOneScan(t *testing.T) {
 	mockOrchestratorStorage.EXPECT().GetLastReorgCheckedBlockNumber(big.NewInt(1)).Return(big.NewInt(1), nil)
 	handler := NewReorgHandler(mockRPC, mockStorage)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(9), big.NewInt(8), big.NewInt(7), big.NewInt(6), big.NewInt(5), big.NewInt(4), big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(9), big.NewInt(8), big.NewInt(7), big.NewInt(6), big.NewInt(5), big.NewInt(4), big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(9), Data: common.Block{Hash: "hash9", ParentHash: "hash8"}},
 		{BlockNumber: big.NewInt(8), Data: common.Block{Hash: "hash8", ParentHash: "hash7"}},
 		{BlockNumber: big.NewInt(7), Data: common.Block{Hash: "hash7", ParentHash: "hash6"}},
@@ -330,7 +330,7 @@ func TestFindManyReorgsInOneScan(t *testing.T) {
 	}
 
 	reorgedBlockNumbers := []*big.Int{}
-	err := handler.findReorgedBlockNumbers(initialBlockHeaders, &reorgedBlockNumbers)
+	err := handler.findReorgedBlockNumbers(context.Background(), initialBlockHeaders, &reorgedBlockNumbers)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []*big.Int{big.NewInt(9), big.NewInt(6), big.NewInt(4)}, reorgedBlockNumbers)
@@ -354,14 +354,14 @@ func TestFindManyReorgsInOneScanRecursively(t *testing.T) {
 	mockOrchestratorStorage.EXPECT().GetLastReorgCheckedBlockNumber(big.NewInt(1)).Return(big.NewInt(1), nil)
 	handler := NewReorgHandler(mockRPC, mockStorage)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(9), big.NewInt(8), big.NewInt(7), big.NewInt(6)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(9), big.NewInt(8), big.NewInt(7), big.NewInt(6)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(9), Data: common.Block{Hash: "hash9", ParentHash: "hash8"}},
 		{BlockNumber: big.NewInt(8), Data: common.Block{Hash: "hash8", ParentHash: "hash7"}},
 		{BlockNumber: big.NewInt(7), Data: common.Block{Hash: "hash7", ParentHash: "hash6"}},
 		{BlockNumber: big.NewInt(6), Data: common.Block{Hash: "hash6", ParentHash: "hash5"}},
 	}).Once()
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(5), big.NewInt(4), big.NewInt(3), big.NewInt(2)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(5), big.NewInt(4), big.NewInt(3), big.NewInt(2)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(5), Data: common.Block{Hash: "hash5", ParentHash: "hash4"}},
 		{BlockNumber: big.NewInt(4), Data: common.Block{Hash: "hash4", ParentHash: "hash3"}},
 		{BlockNumber: big.NewInt(3), Data: common.Block{Hash: "hash3", ParentHash: "hash2"}},
@@ -383,7 +383,7 @@ func TestFindManyReorgsInOneScanRecursively(t *testing.T) {
 	}, nil)
 
 	reorgedBlockNumbers := []*big.Int{}
-	err := handler.findReorgedBlockNumbers(initialBlockHeaders, &reorgedBlockNumbers)
+	err := handler.findReorgedBlockNumbers(context.Background(), initialBlockHeaders, &reorgedBlockNumbers)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []*big.Int{big.NewInt(9), big.NewInt(6), big.NewInt(4), big.NewInt(3)}, reorgedBlockNumbers)
@@ -407,13 +407,13 @@ func TestFindReorgedBlockNumbersRecursively(t *testing.T) {
 	mockOrchestratorStorage.EXPECT().GetLastReorgCheckedBlockNumber(big.NewInt(1)).Return(big.NewInt(3), nil)
 	handler := NewReorgHandler(mockRPC, mockStorage)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(6), big.NewInt(5), big.NewInt(4)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(6), big.NewInt(5), big.NewInt(4)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(6), Data: common.Block{Hash: "hash6", ParentHash: "hash5"}},
 		{BlockNumber: big.NewInt(5), Data: common.Block{Hash: "hash5", ParentHash: "hash4"}},
 		{BlockNumber: big.NewInt(4), Data: common.Block{Hash: "hash4", ParentHash: "hash3"}},
 	}).Once()
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(3), big.NewInt(2), big.NewInt(1)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(3), Data: common.Block{Hash: "hash3", ParentHash: "hash2"}},
 		{BlockNumber: big.NewInt(2), Data: common.Block{Hash: "hash2", ParentHash: "hash1"}},
 		{BlockNumber: big.NewInt(1), Data: common.Block{Hash: "hash1", ParentHash: "hash0"}},
@@ -432,7 +432,7 @@ func TestFindReorgedBlockNumbersRecursively(t *testing.T) {
 	}, nil)
 
 	reorgedBlockNumbers := []*big.Int{}
-	err := handler.findReorgedBlockNumbers(initialBlockHeaders, &reorgedBlockNumbers)
+	err := handler.findReorgedBlockNumbers(context.Background(), initialBlockHeaders, &reorgedBlockNumbers)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []*big.Int{big.NewInt(6), big.NewInt(5), big.NewInt(4), big.NewInt(3)}, reorgedBlockNumbers)
@@ -456,17 +456,17 @@ func TestNewBlocksAreFetchedInBatches(t *testing.T) {
 	mockOrchestratorStorage.EXPECT().GetLastReorgCheckedBlockNumber(big.NewInt(1)).Return(big.NewInt(3), nil)
 	handler := NewReorgHandler(mockRPC, mockStorage)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(6), big.NewInt(5)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(6), big.NewInt(5)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(6), Data: common.Block{Hash: "hash6", ParentHash: "hash5"}},
 		{BlockNumber: big.NewInt(5), Data: common.Block{Hash: "hash5", ParentHash: "hash4"}},
 	}).Once()
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(4), big.NewInt(3)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(4), big.NewInt(3)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(4), Data: common.Block{Hash: "hash4", ParentHash: "hash3"}},
 		{BlockNumber: big.NewInt(3), Data: common.Block{Hash: "hash3", ParentHash: "hash2"}},
 	}).Once()
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(2)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(2)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(2), Data: common.Block{Hash: "hash2", ParentHash: "hash1"}},
 	}).Once()
 
@@ -479,7 +479,7 @@ func TestNewBlocksAreFetchedInBatches(t *testing.T) {
 	}
 
 	reorgedBlockNumbers := []*big.Int{}
-	err := handler.findReorgedBlockNumbers(initialBlockHeaders, &reorgedBlockNumbers)
+	err := handler.findReorgedBlockNumbers(context.Background(), initialBlockHeaders, &reorgedBlockNumbers)
 
 	assert.NoError(t, err)
 	assert.Equal(t, []*big.Int{}, reorgedBlockNumbers)
@@ -497,7 +497,7 @@ func TestHandleReorg(t *testing.T) {
 
 	mockRPC.EXPECT().GetChainID().Return(big.NewInt(1))
 	mockRPC.EXPECT().GetBlocksPerRequest().Return(rpc.BlocksPerRequestConfig{Blocks: 100})
-	mockRPC.EXPECT().GetFullBlocks(mock.Anything).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), mock.Anything).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(1), Data: common.BlockData{}},
 		{BlockNumber: big.NewInt(2), Data: common.BlockData{}},
 		{BlockNumber: big.NewInt(3), Data: common.BlockData{}},
@@ -507,7 +507,7 @@ func TestHandleReorg(t *testing.T) {
 	mockMainStorage.EXPECT().ReplaceBlockData(mock.Anything).Return([]common.BlockData{}, nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	err := handler.handleReorg([]*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)})
+	err := handler.handleReorg(context.Background(), []*big.Int{big.NewInt(1), big.NewInt(2), big.NewInt(3)})
 
 	assert.NoError(t, err)
 }
@@ -560,7 +560,7 @@ func TestReorgHandlingIsSkippedIfMostRecentAndLastCheckedBlockAreSame(t *testing
 	mockMainStorage.EXPECT().GetMaxBlockNumber(big.NewInt(1)).Return(big.NewInt(100), nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	mostRecentBlockChecked, err := handler.RunFromBlock(big.NewInt(100))
+	mostRecentBlockChecked, err := handler.RunFromBlock(context.Background(), big.NewInt(100))
 
 	assert.NoError(t, err)
 	assert.Nil(t, mostRecentBlockChecked)
@@ -597,7 +597,7 @@ func TestHandleReorgWithSingleBlockReorg(t *testing.T) {
 		{Number: big.NewInt(100), Hash: "hash100", ParentHash: "hash99"},
 	}, nil)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101), big.NewInt(100)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101), big.NewInt(100)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(105), Data: common.Block{Hash: "hash105", ParentHash: "hash104"}},
 		{BlockNumber: big.NewInt(104), Data: common.Block{Hash: "hash104", ParentHash: "hash103"}},
 		{BlockNumber: big.NewInt(103), Data: common.Block{Hash: "hash103", ParentHash: "hash102"}},
@@ -606,7 +606,7 @@ func TestHandleReorgWithSingleBlockReorg(t *testing.T) {
 		{BlockNumber: big.NewInt(100), Data: common.Block{Hash: "hash100", ParentHash: "hash99"}},
 	})
 
-	mockRPC.EXPECT().GetFullBlocks([]*big.Int{big.NewInt(105)}).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), []*big.Int{big.NewInt(105)}).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(105), Data: common.BlockData{}},
 	})
 
@@ -615,7 +615,7 @@ func TestHandleReorgWithSingleBlockReorg(t *testing.T) {
 	})).Return([]common.BlockData{}, nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	mostRecentBlockChecked, err := handler.RunFromBlock(big.NewInt(99))
+	mostRecentBlockChecked, err := handler.RunFromBlock(context.Background(), big.NewInt(99))
 
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(109), mostRecentBlockChecked)
@@ -652,7 +652,7 @@ func TestHandleReorgWithLatestBlockReorged(t *testing.T) {
 		{Number: big.NewInt(100), Hash: "hash100", ParentHash: "hash99"},
 	}, nil)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(108), big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101), big.NewInt(100)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(108), big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101), big.NewInt(100)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(108), Data: common.Block{Hash: "hash108", ParentHash: "hash107"}},
 		{BlockNumber: big.NewInt(107), Data: common.Block{Hash: "hash107", ParentHash: "hash106"}},
 		{BlockNumber: big.NewInt(106), Data: common.Block{Hash: "hash106", ParentHash: "hash105"}},
@@ -664,7 +664,7 @@ func TestHandleReorgWithLatestBlockReorged(t *testing.T) {
 		{BlockNumber: big.NewInt(100), Data: common.Block{Hash: "hash100", ParentHash: "hash99"}},
 	})
 
-	mockRPC.EXPECT().GetFullBlocks([]*big.Int{big.NewInt(108), big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101)}).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), []*big.Int{big.NewInt(108), big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101)}).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(101), Data: common.BlockData{}},
 		{BlockNumber: big.NewInt(102), Data: common.BlockData{}},
 		{BlockNumber: big.NewInt(103), Data: common.BlockData{}},
@@ -680,7 +680,7 @@ func TestHandleReorgWithLatestBlockReorged(t *testing.T) {
 	})).Return([]common.BlockData{}, nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	mostRecentBlockChecked, err := handler.RunFromBlock(big.NewInt(99))
+	mostRecentBlockChecked, err := handler.RunFromBlock(context.Background(), big.NewInt(99))
 
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(109), mostRecentBlockChecked)
@@ -717,7 +717,7 @@ func TestHandleReorgWithManyBlocks(t *testing.T) {
 		{Number: big.NewInt(100), Hash: "hash100", ParentHash: "hash99"},
 	}, nil)
 
-	mockRPC.EXPECT().GetBlocks([]*big.Int{big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101), big.NewInt(100)}).Return([]rpc.GetBlocksResult{
+	mockRPC.EXPECT().GetBlocks(context.Background(), []*big.Int{big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103), big.NewInt(102), big.NewInt(101), big.NewInt(100)}).Return([]rpc.GetBlocksResult{
 		{BlockNumber: big.NewInt(107), Data: common.Block{Hash: "hash107", ParentHash: "hash106"}},
 		{BlockNumber: big.NewInt(106), Data: common.Block{Hash: "hash106", ParentHash: "hash105"}},
 		{BlockNumber: big.NewInt(105), Data: common.Block{Hash: "hash105", ParentHash: "hash104"}},
@@ -728,7 +728,7 @@ func TestHandleReorgWithManyBlocks(t *testing.T) {
 		{BlockNumber: big.NewInt(100), Data: common.Block{Hash: "hash100", ParentHash: "hash99"}},
 	})
 
-	mockRPC.EXPECT().GetFullBlocks([]*big.Int{big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103)}).Return([]rpc.GetFullBlockResult{
+	mockRPC.EXPECT().GetFullBlocks(context.Background(), []*big.Int{big.NewInt(107), big.NewInt(106), big.NewInt(105), big.NewInt(104), big.NewInt(103)}).Return([]rpc.GetFullBlockResult{
 		{BlockNumber: big.NewInt(107), Data: common.BlockData{}},
 		{BlockNumber: big.NewInt(106), Data: common.BlockData{}},
 		{BlockNumber: big.NewInt(105), Data: common.BlockData{}},
@@ -741,7 +741,7 @@ func TestHandleReorgWithManyBlocks(t *testing.T) {
 	})).Return([]common.BlockData{}, nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	mostRecentBlockChecked, err := handler.RunFromBlock(big.NewInt(99))
+	mostRecentBlockChecked, err := handler.RunFromBlock(context.Background(), big.NewInt(99))
 
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(109), mostRecentBlockChecked)
@@ -778,7 +778,7 @@ func TestHandleReorgWithDuplicateBlocks(t *testing.T) {
 	}, nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	mostRecentBlockChecked, err := handler.RunFromBlock(big.NewInt(6268162))
+	mostRecentBlockChecked, err := handler.RunFromBlock(context.Background(), big.NewInt(6268162))
 
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(6268172), mostRecentBlockChecked)
@@ -815,7 +815,7 @@ func TestNothingIsDoneForCorrectBlocks(t *testing.T) {
 	}, nil)
 
 	handler := NewReorgHandler(mockRPC, mockStorage)
-	mostRecentBlockChecked, err := handler.RunFromBlock(big.NewInt(6268163))
+	mostRecentBlockChecked, err := handler.RunFromBlock(context.Background(), big.NewInt(6268163))
 
 	assert.NoError(t, err)
 	assert.Equal(t, big.NewInt(6268173), mostRecentBlockChecked)

--- a/internal/rpc/batcher.go
+++ b/internal/rpc/batcher.go
@@ -16,9 +16,9 @@ type RPCFetchBatchResult[K any, T any] struct {
 	Result T
 }
 
-func RPCFetchInBatches[K any, T any](rpc *Client, keys []K, batchSize int, batchDelay int, method string, argsFunc func(K) []interface{}) []RPCFetchBatchResult[K, T] {
+func RPCFetchInBatches[K any, T any](rpc *Client, ctx context.Context, keys []K, batchSize int, batchDelay int, method string, argsFunc func(K) []interface{}) []RPCFetchBatchResult[K, T] {
 	if len(keys) <= batchSize {
-		return RPCFetchSingleBatch[K, T](rpc, keys, method, argsFunc)
+		return RPCFetchSingleBatch[K, T](rpc, ctx, keys, method, argsFunc)
 	}
 	chunks := common.SliceToChunks[K](keys, batchSize)
 
@@ -31,7 +31,7 @@ func RPCFetchInBatches[K any, T any](rpc *Client, keys []K, batchSize int, batch
 		wg.Add(1)
 		go func(chunk []K) {
 			defer wg.Done()
-			resultsCh <- RPCFetchSingleBatch[K, T](rpc, chunk, method, argsFunc)
+			resultsCh <- RPCFetchSingleBatch[K, T](rpc, ctx, chunk, method, argsFunc)
 			if batchDelay > 0 {
 				time.Sleep(time.Duration(batchDelay) * time.Millisecond)
 			}
@@ -50,7 +50,7 @@ func RPCFetchInBatches[K any, T any](rpc *Client, keys []K, batchSize int, batch
 	return results
 }
 
-func RPCFetchSingleBatch[K any, T any](rpc *Client, keys []K, method string, argsFunc func(K) []interface{}) []RPCFetchBatchResult[K, T] {
+func RPCFetchSingleBatch[K any, T any](rpc *Client, ctx context.Context, keys []K, method string, argsFunc func(K) []interface{}) []RPCFetchBatchResult[K, T] {
 	batch := make([]gethRpc.BatchElem, len(keys))
 	results := make([]RPCFetchBatchResult[K, T], len(keys))
 
@@ -63,7 +63,7 @@ func RPCFetchSingleBatch[K any, T any](rpc *Client, keys []K, method string, arg
 		}
 	}
 
-	err := rpc.RPCClient.BatchCallContext(context.Background(), batch)
+	err := rpc.RPCClient.BatchCallContext(ctx, batch)
 	if err != nil {
 		for i := range results {
 			results[i].Error = err

--- a/test/mocks/MockIRPCClient.go
+++ b/test/mocks/MockIRPCClient.go
@@ -5,9 +5,11 @@
 package mocks
 
 import (
+	context "context"
 	big "math/big"
 
 	mock "github.com/stretchr/testify/mock"
+
 	rpc "github.com/thirdweb-dev/indexer/internal/rpc"
 )
 
@@ -56,17 +58,17 @@ func (_c *MockIRPCClient_Close_Call) RunAndReturn(run func()) *MockIRPCClient_Cl
 	return _c
 }
 
-// GetBlocks provides a mock function with given fields: blockNumbers
-func (_m *MockIRPCClient) GetBlocks(blockNumbers []*big.Int) []rpc.GetBlocksResult {
-	ret := _m.Called(blockNumbers)
+// GetBlocks provides a mock function with given fields: ctx, blockNumbers
+func (_m *MockIRPCClient) GetBlocks(ctx context.Context, blockNumbers []*big.Int) []rpc.GetBlocksResult {
+	ret := _m.Called(ctx, blockNumbers)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBlocks")
 	}
 
 	var r0 []rpc.GetBlocksResult
-	if rf, ok := ret.Get(0).(func([]*big.Int) []rpc.GetBlocksResult); ok {
-		r0 = rf(blockNumbers)
+	if rf, ok := ret.Get(0).(func(context.Context, []*big.Int) []rpc.GetBlocksResult); ok {
+		r0 = rf(ctx, blockNumbers)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]rpc.GetBlocksResult)
@@ -82,14 +84,15 @@ type MockIRPCClient_GetBlocks_Call struct {
 }
 
 // GetBlocks is a helper method to define mock.On call
+//   - ctx context.Context
 //   - blockNumbers []*big.Int
-func (_e *MockIRPCClient_Expecter) GetBlocks(blockNumbers interface{}) *MockIRPCClient_GetBlocks_Call {
-	return &MockIRPCClient_GetBlocks_Call{Call: _e.mock.On("GetBlocks", blockNumbers)}
+func (_e *MockIRPCClient_Expecter) GetBlocks(ctx interface{}, blockNumbers interface{}) *MockIRPCClient_GetBlocks_Call {
+	return &MockIRPCClient_GetBlocks_Call{Call: _e.mock.On("GetBlocks", ctx, blockNumbers)}
 }
 
-func (_c *MockIRPCClient_GetBlocks_Call) Run(run func(blockNumbers []*big.Int)) *MockIRPCClient_GetBlocks_Call {
+func (_c *MockIRPCClient_GetBlocks_Call) Run(run func(ctx context.Context, blockNumbers []*big.Int)) *MockIRPCClient_GetBlocks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]*big.Int))
+		run(args[0].(context.Context), args[1].([]*big.Int))
 	})
 	return _c
 }
@@ -99,7 +102,7 @@ func (_c *MockIRPCClient_GetBlocks_Call) Return(_a0 []rpc.GetBlocksResult) *Mock
 	return _c
 }
 
-func (_c *MockIRPCClient_GetBlocks_Call) RunAndReturn(run func([]*big.Int) []rpc.GetBlocksResult) *MockIRPCClient_GetBlocks_Call {
+func (_c *MockIRPCClient_GetBlocks_Call) RunAndReturn(run func(context.Context, []*big.Int) []rpc.GetBlocksResult) *MockIRPCClient_GetBlocks_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -196,17 +199,17 @@ func (_c *MockIRPCClient_GetChainID_Call) RunAndReturn(run func() *big.Int) *Moc
 	return _c
 }
 
-// GetFullBlocks provides a mock function with given fields: blockNumbers
-func (_m *MockIRPCClient) GetFullBlocks(blockNumbers []*big.Int) []rpc.GetFullBlockResult {
-	ret := _m.Called(blockNumbers)
+// GetFullBlocks provides a mock function with given fields: ctx, blockNumbers
+func (_m *MockIRPCClient) GetFullBlocks(ctx context.Context, blockNumbers []*big.Int) []rpc.GetFullBlockResult {
+	ret := _m.Called(ctx, blockNumbers)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetFullBlocks")
 	}
 
 	var r0 []rpc.GetFullBlockResult
-	if rf, ok := ret.Get(0).(func([]*big.Int) []rpc.GetFullBlockResult); ok {
-		r0 = rf(blockNumbers)
+	if rf, ok := ret.Get(0).(func(context.Context, []*big.Int) []rpc.GetFullBlockResult); ok {
+		r0 = rf(ctx, blockNumbers)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]rpc.GetFullBlockResult)
@@ -222,14 +225,15 @@ type MockIRPCClient_GetFullBlocks_Call struct {
 }
 
 // GetFullBlocks is a helper method to define mock.On call
+//   - ctx context.Context
 //   - blockNumbers []*big.Int
-func (_e *MockIRPCClient_Expecter) GetFullBlocks(blockNumbers interface{}) *MockIRPCClient_GetFullBlocks_Call {
-	return &MockIRPCClient_GetFullBlocks_Call{Call: _e.mock.On("GetFullBlocks", blockNumbers)}
+func (_e *MockIRPCClient_Expecter) GetFullBlocks(ctx interface{}, blockNumbers interface{}) *MockIRPCClient_GetFullBlocks_Call {
+	return &MockIRPCClient_GetFullBlocks_Call{Call: _e.mock.On("GetFullBlocks", ctx, blockNumbers)}
 }
 
-func (_c *MockIRPCClient_GetFullBlocks_Call) Run(run func(blockNumbers []*big.Int)) *MockIRPCClient_GetFullBlocks_Call {
+func (_c *MockIRPCClient_GetFullBlocks_Call) Run(run func(ctx context.Context, blockNumbers []*big.Int)) *MockIRPCClient_GetFullBlocks_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]*big.Int))
+		run(args[0].(context.Context), args[1].([]*big.Int))
 	})
 	return _c
 }
@@ -239,14 +243,14 @@ func (_c *MockIRPCClient_GetFullBlocks_Call) Return(_a0 []rpc.GetFullBlockResult
 	return _c
 }
 
-func (_c *MockIRPCClient_GetFullBlocks_Call) RunAndReturn(run func([]*big.Int) []rpc.GetFullBlockResult) *MockIRPCClient_GetFullBlocks_Call {
+func (_c *MockIRPCClient_GetFullBlocks_Call) RunAndReturn(run func(context.Context, []*big.Int) []rpc.GetFullBlockResult) *MockIRPCClient_GetFullBlocks_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetLatestBlockNumber provides a mock function with no fields
-func (_m *MockIRPCClient) GetLatestBlockNumber() (*big.Int, error) {
-	ret := _m.Called()
+// GetLatestBlockNumber provides a mock function with given fields: ctx
+func (_m *MockIRPCClient) GetLatestBlockNumber(ctx context.Context) (*big.Int, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetLatestBlockNumber")
@@ -254,19 +258,19 @@ func (_m *MockIRPCClient) GetLatestBlockNumber() (*big.Int, error) {
 
 	var r0 *big.Int
 	var r1 error
-	if rf, ok := ret.Get(0).(func() (*big.Int, error)); ok {
-		return rf()
+	if rf, ok := ret.Get(0).(func(context.Context) (*big.Int, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func() *big.Int); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) *big.Int); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -280,13 +284,14 @@ type MockIRPCClient_GetLatestBlockNumber_Call struct {
 }
 
 // GetLatestBlockNumber is a helper method to define mock.On call
-func (_e *MockIRPCClient_Expecter) GetLatestBlockNumber() *MockIRPCClient_GetLatestBlockNumber_Call {
-	return &MockIRPCClient_GetLatestBlockNumber_Call{Call: _e.mock.On("GetLatestBlockNumber")}
+//   - ctx context.Context
+func (_e *MockIRPCClient_Expecter) GetLatestBlockNumber(ctx interface{}) *MockIRPCClient_GetLatestBlockNumber_Call {
+	return &MockIRPCClient_GetLatestBlockNumber_Call{Call: _e.mock.On("GetLatestBlockNumber", ctx)}
 }
 
-func (_c *MockIRPCClient_GetLatestBlockNumber_Call) Run(run func()) *MockIRPCClient_GetLatestBlockNumber_Call {
+func (_c *MockIRPCClient_GetLatestBlockNumber_Call) Run(run func(ctx context.Context)) *MockIRPCClient_GetLatestBlockNumber_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -296,22 +301,22 @@ func (_c *MockIRPCClient_GetLatestBlockNumber_Call) Return(_a0 *big.Int, _a1 err
 	return _c
 }
 
-func (_c *MockIRPCClient_GetLatestBlockNumber_Call) RunAndReturn(run func() (*big.Int, error)) *MockIRPCClient_GetLatestBlockNumber_Call {
+func (_c *MockIRPCClient_GetLatestBlockNumber_Call) RunAndReturn(run func(context.Context) (*big.Int, error)) *MockIRPCClient_GetLatestBlockNumber_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetTransactions provides a mock function with given fields: txHashes
-func (_m *MockIRPCClient) GetTransactions(txHashes []string) []rpc.GetTransactionsResult {
-	ret := _m.Called(txHashes)
+// GetTransactions provides a mock function with given fields: ctx, txHashes
+func (_m *MockIRPCClient) GetTransactions(ctx context.Context, txHashes []string) []rpc.GetTransactionsResult {
+	ret := _m.Called(ctx, txHashes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetTransactions")
 	}
 
 	var r0 []rpc.GetTransactionsResult
-	if rf, ok := ret.Get(0).(func([]string) []rpc.GetTransactionsResult); ok {
-		r0 = rf(txHashes)
+	if rf, ok := ret.Get(0).(func(context.Context, []string) []rpc.GetTransactionsResult); ok {
+		r0 = rf(ctx, txHashes)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]rpc.GetTransactionsResult)
@@ -327,14 +332,15 @@ type MockIRPCClient_GetTransactions_Call struct {
 }
 
 // GetTransactions is a helper method to define mock.On call
+//   - ctx context.Context
 //   - txHashes []string
-func (_e *MockIRPCClient_Expecter) GetTransactions(txHashes interface{}) *MockIRPCClient_GetTransactions_Call {
-	return &MockIRPCClient_GetTransactions_Call{Call: _e.mock.On("GetTransactions", txHashes)}
+func (_e *MockIRPCClient_Expecter) GetTransactions(ctx interface{}, txHashes interface{}) *MockIRPCClient_GetTransactions_Call {
+	return &MockIRPCClient_GetTransactions_Call{Call: _e.mock.On("GetTransactions", ctx, txHashes)}
 }
 
-func (_c *MockIRPCClient_GetTransactions_Call) Run(run func(txHashes []string)) *MockIRPCClient_GetTransactions_Call {
+func (_c *MockIRPCClient_GetTransactions_Call) Run(run func(ctx context.Context, txHashes []string)) *MockIRPCClient_GetTransactions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].([]string))
+		run(args[0].(context.Context), args[1].([]string))
 	})
 	return _c
 }
@@ -344,7 +350,7 @@ func (_c *MockIRPCClient_GetTransactions_Call) Return(_a0 []rpc.GetTransactionsR
 	return _c
 }
 
-func (_c *MockIRPCClient_GetTransactions_Call) RunAndReturn(run func([]string) []rpc.GetTransactionsResult) *MockIRPCClient_GetTransactions_Call {
+func (_c *MockIRPCClient_GetTransactions_Call) RunAndReturn(run func(context.Context, []string) []rpc.GetTransactionsResult) *MockIRPCClient_GetTransactions_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -394,9 +400,9 @@ func (_c *MockIRPCClient_GetURL_Call) RunAndReturn(run func() string) *MockIRPCC
 	return _c
 }
 
-// HasCode provides a mock function with given fields: address
-func (_m *MockIRPCClient) HasCode(address string) (bool, error) {
-	ret := _m.Called(address)
+// HasCode provides a mock function with given fields: ctx, address
+func (_m *MockIRPCClient) HasCode(ctx context.Context, address string) (bool, error) {
+	ret := _m.Called(ctx, address)
 
 	if len(ret) == 0 {
 		panic("no return value specified for HasCode")
@@ -404,17 +410,17 @@ func (_m *MockIRPCClient) HasCode(address string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return rf(address)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return rf(ctx, address)
 	}
-	if rf, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = rf(address)
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, address)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(address)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, address)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -428,14 +434,15 @@ type MockIRPCClient_HasCode_Call struct {
 }
 
 // HasCode is a helper method to define mock.On call
+//   - ctx context.Context
 //   - address string
-func (_e *MockIRPCClient_Expecter) HasCode(address interface{}) *MockIRPCClient_HasCode_Call {
-	return &MockIRPCClient_HasCode_Call{Call: _e.mock.On("HasCode", address)}
+func (_e *MockIRPCClient_Expecter) HasCode(ctx interface{}, address interface{}) *MockIRPCClient_HasCode_Call {
+	return &MockIRPCClient_HasCode_Call{Call: _e.mock.On("HasCode", ctx, address)}
 }
 
-func (_c *MockIRPCClient_HasCode_Call) Run(run func(address string)) *MockIRPCClient_HasCode_Call {
+func (_c *MockIRPCClient_HasCode_Call) Run(run func(ctx context.Context, address string)) *MockIRPCClient_HasCode_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -445,7 +452,7 @@ func (_c *MockIRPCClient_HasCode_Call) Return(_a0 bool, _a1 error) *MockIRPCClie
 	return _c
 }
 
-func (_c *MockIRPCClient_HasCode_Call) RunAndReturn(run func(string) (bool, error)) *MockIRPCClient_HasCode_Call {
+func (_c *MockIRPCClient_HasCode_Call) RunAndReturn(run func(context.Context, string) (bool, error)) *MockIRPCClient_HasCode_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
### TL;DR

Added context propagation throughout the codebase to improve cancellation handling and resource management.

### What changed?

This PR adds proper context propagation throughout the codebase by:

1. Adding context parameters to all RPC client interface methods:
   - `GetFullBlocks`
   - `GetBlocks`
   - `GetTransactions`
   - `GetLatestBlockNumber`

2. Updating all orchestrator components to pass context to RPC calls:
   - ChainTracker
   - Committer
   - FailureRecoverer
   - Poller
   - ReorgHandler

3. Propagating context through the worker package to ensure proper cancellation handling

4. Updating all batch RPC operations to respect context cancellation

### How to test?

1. Run the application and verify that it functions normally
2. Test context cancellation by:
   - Starting the application
   - Triggering a graceful shutdown
   - Verifying that in-progress operations are properly canceled

### Why make this change?

This change improves resource management and application behavior by:

1. Ensuring proper cancellation of in-progress operations when the application is shutting down
2. Preventing resource leaks by propagating context through all layers of the application
3. Following Go best practices for handling context propagation
4. Enabling better timeout and cancellation handling for RPC operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for cancellation and timeout controls to blockchain data fetching and processing operations, improving responsiveness and robustness of long-running tasks.
  - Introduced context propagation to search functionality for better request handling and cancellation support.

- **Bug Fixes**
  - Enhanced cancellation and timeout handling across multiple components to prevent unresponsive or hanging processes.

- **Tests**
  - Updated tests to validate context-aware operations and ensure proper handling of cancellations and timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->