### PR TITLE
do not save non-existing to_address as null address

### DIFF
--- a/internal/rpc/serializer.go
+++ b/internal/rpc/serializer.go
@@ -167,21 +167,15 @@ func serializeTransactions(chainId *big.Int, transactions []interface{}, blockTi
 
 func serializeTransaction(chainId *big.Int, tx map[string]interface{}, blockTimestamp time.Time, receipt *common.RawReceipt) common.Transaction {
 	return common.Transaction{
-		ChainId:          chainId,
-		Hash:             interfaceToString(tx["hash"]),
-		Nonce:            hexToUint64(tx["nonce"]),
-		BlockHash:        interfaceToString(tx["blockHash"]),
-		BlockNumber:      hexToBigInt(tx["blockNumber"]),
-		BlockTimestamp:   blockTimestamp,
-		TransactionIndex: hexToUint64(tx["transactionIndex"]),
-		FromAddress:      interfaceToString(tx["from"]),
-		ToAddress: func() string {
-			to := interfaceToString(tx["to"])
-			if to != "" {
-				return to
-			}
-			return "0x0000000000000000000000000000000000000000"
-		}(),
+		ChainId:              chainId,
+		Hash:                 interfaceToString(tx["hash"]),
+		Nonce:                hexToUint64(tx["nonce"]),
+		BlockHash:            interfaceToString(tx["blockHash"]),
+		BlockNumber:          hexToBigInt(tx["blockNumber"]),
+		BlockTimestamp:       blockTimestamp,
+		TransactionIndex:     hexToUint64(tx["transactionIndex"]),
+		FromAddress:          interfaceToString(tx["from"]),
+		ToAddress:            interfaceToString(tx["to"]),
 		Value:                hexToBigInt(tx["value"]),
 		Gas:                  hexToUint64(tx["gas"]),
 		GasPrice:             hexToBigInt(tx["gasPrice"]),

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -32,6 +32,7 @@ type InsertOptions struct {
 var DEFAULT_MAX_ROWS_PER_INSERT = 100000
 var ZERO_BYTES_66 = strings.Repeat("\x00", 66)
 var ZERO_BYTES_10 = strings.Repeat("\x00", 10)
+var ZERO_BYTES_42 = strings.Repeat("\x00", 42)
 
 var defaultBlockFields = []string{
 	"chain_id", "block_number", "hash", "parent_hash", "block_timestamp", "nonce",
@@ -748,6 +749,9 @@ func scanTransaction(rows driver.Rows) (common.Transaction, error) {
 	}
 	if tx.FunctionSelector == ZERO_BYTES_10 {
 		tx.FunctionSelector = ""
+	}
+	if tx.ToAddress == ZERO_BYTES_42 {
+		tx.ToAddress = ""
 	}
 	return tx, nil
 }


### PR DESCRIPTION
### TL;DR

Changed how null transaction recipients are handled in the codebase.

### What changed?

- Modified `serializeTransaction` function to directly assign the `to` field value without replacing empty values with a zero address
- Added a new constant `ZERO_BYTES_42` for handling empty address strings
- Updated the `scanTransaction` function to convert zero-byte address strings back to empty strings when retrieving transaction data

### How to test?

1. Process transactions with null recipients (contract creation transactions)
2. Verify that these transactions have empty `ToAddress` fields instead of zero addresses
3. Confirm that transactions can be properly retrieved from storage with the correct representation of null recipients

### Why make this change?

This change provides a more accurate representation of contract creation transactions, which have no recipient address. Instead of replacing empty recipient addresses with the zero address (0x0000000000000000000000000000000000000000), the code now preserves the empty value, making it clearer when a transaction is creating a contract versus sending to the zero address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of transactions with missing or zero-filled "to" addresses, ensuring these are now consistently represented as empty strings in relevant cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->