### PR TITLE
close body when fetching abi

### DIFF
--- a/internal/common/abi.go
+++ b/internal/common/abi.go
@@ -38,6 +38,11 @@ func GetABIForContract(chainId string, contract string) (*abi.ABI, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to get contract abi: %v", err)
 	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get contract abi: unexpected status code %d", resp.StatusCode)
+	}
 
 	abi, err := abi.JSON(resp.Body)
 	if err != nil {


### PR DESCRIPTION
### TL;DR

Added proper HTTP response handling in the GetABIForContract function.

### What changed?

- Added `defer resp.Body.Close()` to ensure the response body is properly closed after use
- Added a check for the HTTP status code to verify that the response is successful (200 OK)
- Added error handling for non-200 status codes with a descriptive error message

### How to test?

1. Test the function with a valid contract address and chain ID to ensure it still works correctly
2. Test with an invalid or non-existent contract to verify the proper error is returned
3. Test with a scenario where the API returns a non-200 status code to ensure the error is properly handled

### Why make this change?

This change improves error handling and resource management in the GetABIForContract function. The previous implementation didn't close the response body, which could lead to resource leaks, and didn't check the HTTP status code, which could lead to unexpected behavior when the API returns an error status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when fetching contract information by enhancing error handling and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->