### PR TITLE
add timeout to abi request

### DIFF
--- a/internal/common/abi.go
+++ b/internal/common/abi.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	config "github.com/thirdweb-dev/indexer/configs"
 
@@ -34,7 +35,12 @@ func GetABIForContractWithCache(chainId string, contract string, abiCache map[st
 func GetABIForContract(chainId string, contract string) (*abi.ABI, error) {
 	url := fmt.Sprintf("%s/abi/%s/%s", config.Cfg.API.ThirdwebContractApi, chainId, contract)
 
-	resp, err := http.Get(url)
+	// Create a custom client with timeouts
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(url)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get contract abi: %v", err)
 	}


### PR DESCRIPTION
### TL;DR

Added HTTP timeout for ABI fetching operations to prevent hanging requests.

### What changed?

- Added a 10-second timeout to the HTTP client used for fetching contract ABIs
- Imported the `time` package to support the timeout functionality
- Replaced the direct `http.Get()` call with a custom client that has timeout configuration

### How to test?

1. Verify that ABI fetching operations complete or fail within 10 seconds
2. Test with a slow or unresponsive API endpoint to confirm the timeout works correctly
3. Ensure existing ABI fetching functionality continues to work normally with responsive endpoints

### Why make this change?

Without a timeout, HTTP requests to fetch contract ABIs could potentially hang indefinitely if the API endpoint is unresponsive, causing resource leaks and degraded performance. This change ensures that requests will fail gracefully after 10 seconds, allowing the system to handle errors appropriately and maintain responsiveness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of contract ABI fetching by adding a timeout to prevent requests from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->