### PR TITLE
fix: rename countDistinct to countdistinct in allowed functions

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -25,7 +25,7 @@ func SliceToChunks[T any](values []T, chunkSize int) [][]T {
 var allowedFunctions = map[string]struct{}{
 	"sum":                  {},
 	"count":                {},
-	"countDistinct":        {},
+	"countdistinct":        {},
 	"avg":                  {},
 	"max":                  {},
 	"min":                  {},


### PR DESCRIPTION
### TL;DR

We check for allowed lowercased functions so had to change the `countDistinct` function name to lowercase `countdistinct` in the allowed functions map.

### What changed?

Modified the `allowedFunctions` map in `internal/common/utils.go` to use lowercase `countdistinct` instead of the previously camelCase `countDistinct`. This ensures consistent naming convention for function names.

### How to test?

1. Verify that any code using the `countdistinct` function continues to work properly
2. Check that any API calls or queries using this function name are properly recognized
3. Run existing tests to ensure no regressions

### Why make this change?

This change standardizes the function naming convention to use all lowercase for function names in the `allowedFunctions` map. This improves consistency with other function names and likely fixes case-sensitivity issues when these function names are used in queries or API calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved function name validation to recognize only lowercase "countdistinct" as an allowed function, ensuring consistent and accurate query validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->