### PR TITLE
Revert "improve abi parsing (#213)"

### DIFF
--- a/internal/common/abi.go
+++ b/internal/common/abi.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"regexp"
 	"strings"
@@ -12,13 +11,11 @@ import (
 	config "github.com/thirdweb-dev/indexer/configs"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/rs/zerolog/log"
 )
 
 var (
-	httpClient      *http.Client
-	httpClientOnce  sync.Once
-	jsonDecodeMutex sync.Mutex
+	httpClient     *http.Client
+	httpClientOnce sync.Once
 )
 
 func getHTTPClient() *http.Client {
@@ -69,23 +66,11 @@ func GetABIForContract(chainId string, contract string) (*abi.ABI, error) {
 		return nil, fmt.Errorf("failed to get contract abi: unexpected status code %d", resp.StatusCode)
 	}
 
-	// Read the entire response body
-	body, err := io.ReadAll(resp.Body)
+	abi, err := abi.JSON(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read contract abi response: %v", err)
-	}
-
-	// Protect JSON decoding with a mutex
-	jsonDecodeMutex.Lock()
-	defer jsonDecodeMutex.Unlock()
-
-	// Parse the ABI
-	parsedABI, err := abi.JSON(strings.NewReader(string(body)))
-	if err != nil {
-		log.Warn().Err(err).Str("contract", contract).Str("chainId", chainId).Msg("Failed to parse contract ABI")
 		return nil, fmt.Errorf("failed to load contract abi: %v", err)
 	}
-	return &parsedABI, nil
+	return &abi, nil
 }
 
 func ConstructEventABI(signature string) (*abi.Event, error) {


### PR DESCRIPTION
# Simplify ABI Parsing Logic

Refactors the contract ABI fetching logic in `GetABIForContract` by:
- Removing the unnecessary step of reading the entire response body into memory
- Parsing the ABI directly from the response body stream
- Eliminating the JSON decode mutex that's no longer needed
- Removing unused imports (`io` and `log`)

This change makes the code more efficient by avoiding an extra memory allocation and simplifying the error handling path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the process for retrieving and parsing contract ABIs, resulting in a more efficient and streamlined experience when interacting with contract data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->