### PR TITLE
track latest block immediately on start

### DIFF
--- a/internal/orchestrator/chain_tracker.go
+++ b/internal/orchestrator/chain_tracker.go
@@ -29,19 +29,25 @@ func (ct *ChainTracker) Start(ctx context.Context) {
 	defer ticker.Stop()
 
 	log.Debug().Msgf("Chain tracker running")
+	ct.trackLatestBlockNumber(ctx)
+
 	for {
 		select {
 		case <-ctx.Done():
 			log.Info().Msg("Chain tracker shutting down")
 			return
 		case <-ticker.C:
-			latestBlockNumber, err := ct.rpc.GetLatestBlockNumber(ctx)
-			if err != nil {
-				log.Error().Err(err).Msg("Error getting latest block number")
-				continue
-			}
-			latestBlockNumberFloat, _ := latestBlockNumber.Float64()
-			metrics.ChainHead.Set(latestBlockNumberFloat)
+			ct.trackLatestBlockNumber(ctx)
 		}
 	}
+}
+
+func (ct *ChainTracker) trackLatestBlockNumber(ctx context.Context) {
+	latestBlockNumber, err := ct.rpc.GetLatestBlockNumber(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Error getting latest block number")
+		return
+	}
+	latestBlockNumberFloat, _ := latestBlockNumber.Float64()
+	metrics.ChainHead.Set(latestBlockNumberFloat)
 }


### PR DESCRIPTION
### TL;DR

Refactored the ChainTracker to track the latest block number immediately on start and extract the tracking logic into a separate method.

### What changed?

- Extracted the block number tracking logic into a new `trackLatestBlockNumber` method
- Added a call to `trackLatestBlockNumber` immediately after the ChainTracker starts, before entering the main loop
- Updated the ticker handler to call the new method instead of containing the logic directly

### How to test?

1. Start the application and verify that the chain tracker begins tracking the latest block number immediately
2. Check logs to confirm the tracker continues to update at regular intervals
3. Verify that metrics for ChainHead are being set correctly

### Why make this change?

This change improves the ChainTracker by:
1. Tracking the latest block number immediately on startup instead of waiting for the first ticker event
2. Improving code organization by extracting the tracking logic into a reusable method
3. Reducing code duplication between the initial tracking and the periodic updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal logic for tracking and updating the latest block number, resulting in more modular and maintainable code. No changes to user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->