### PR TITLE
log metrics around processing durations

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -105,3 +105,42 @@ var (
 		Help: "The last block number that was published",
 	})
 )
+
+// Operation Duration Metrics
+var (
+	StagingInsertDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "staging_insert_duration_seconds",
+		Help:    "Time taken to insert data into staging storage",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	MainStorageInsertDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "main_storage_insert_duration_seconds",
+		Help:    "Time taken to insert data into main storage",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	PublishDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "publish_duration_seconds",
+		Help:    "Time taken to publish block data to Kafka",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	StagingDeleteDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "staging_delete_duration_seconds",
+		Help:    "Time taken to delete data from staging storage",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	GetBlockNumbersToCommitDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "get_block_numbers_to_commit_duration_seconds",
+		Help:    "Time taken to get block numbers to commit from storage",
+		Buckets: prometheus.DefBuckets,
+	})
+
+	GetStagingDataDuration = promauto.NewHistogram(prometheus.HistogramOpts{
+		Name:    "get_staging_data_duration_seconds",
+		Help:    "Time taken to get data from staging storage",
+		Buckets: prometheus.DefBuckets,
+	})
+)

--- a/internal/orchestrator/poller.go
+++ b/internal/orchestrator/poller.go
@@ -234,6 +234,8 @@ func (p *Poller) handleWorkerResults(results []rpc.GetFullBlockResult) {
 			Traces:       result.Data.Traces,
 		})
 	}
+
+	startTime := time.Now()
 	if err := p.storage.StagingStorage.InsertStagingData(blockData); err != nil {
 		e := fmt.Errorf("error inserting block data: %v", err)
 		log.Error().Err(e)
@@ -245,6 +247,8 @@ func (p *Poller) handleWorkerResults(results []rpc.GetFullBlockResult) {
 		}
 		metrics.PolledBatchSize.Set(float64(len(blockData)))
 	}
+	log.Debug().Str("metric", "staging_insert_duration").Msgf("StagingStorage.InsertStagingData duration: %f", time.Since(startTime).Seconds())
+	metrics.StagingInsertDuration.Observe(time.Since(startTime).Seconds())
 
 	if len(failedResults) > 0 {
 		p.handleBlockFailures(failedResults)


### PR DESCRIPTION
### TL;DR

Added performance metrics for database operations and Kafka publishing.

### What changed?

- Added Prometheus histogram metrics for key operations in the metrics package:
  - `staging_insert_duration_seconds`
  - `main_storage_insert_duration_seconds`
  - `publish_duration_seconds`
  - `staging_delete_duration_seconds`
  - `get_block_numbers_to_commit_duration_seconds`
  - `get_staging_data_duration_seconds`
- Instrumented the `Committer` and `Poller` components with timing measurements
- Added timing for `getBlockNumbersToCommit()` function
- Added timing for staging data retrieval in `getSequentialBlockDataToCommit()`
- Added timing for main storage insertion, Kafka publishing, and staging data deletion in the `commit()` function
- Added timing for staging data insertion in the `handleWorkerResults()` function
- All timing logs use a consistent format with the "metric" field for easier filtering

### How to test?

1. Run the application with debug logging enabled
2. Monitor the logs for entries with `"metric"` field
3. Verify that duration metrics are being reported for all operations
4. Check Prometheus endpoint to confirm metrics are being exposed correctly

### Why make this change?

This change adds detailed performance metrics for database operations and Kafka publishing, which will help identify bottlenecks in the data processing pipeline. By measuring the duration of key operations, we can better understand where performance issues might be occurring and optimize accordingly. The consistent logging format with the "metric" field makes it easier to filter and analyze these performance metrics in log aggregation tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added detailed performance metrics and timing logs for key data handling and publishing operations, including staging and main storage inserts, publishing to Kafka, and data deletion.
  - Introduced Prometheus histogram metrics to monitor operation durations, enhancing observability of system performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->