### PR TITLE
enable parallel view processing for inserts

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -103,6 +103,7 @@ func connectDB(cfg *config.ClickhouseConfig) (clickhouse.Conn, error) {
 				"do_not_merge_across_partitions_select_final": "1",
 				"use_skip_indexes_if_final":                   "1",
 				"optimize_move_to_prewhere_if_final":          "1",
+				"parallel_view_processing":                    "1",
 			}
 			if cfg.AsyncInsert {
 				settings["async_insert"] = "1"


### PR DESCRIPTION
### TL;DR

Enable parallel view processing in ClickHouse connection settings.

### What changed?

Added the `parallel_view_processing` setting with a value of "1" to the ClickHouse connection settings in the `connectDB` function.

### How to test?

1. Deploy the updated code to a test environment
2. Verify that ClickHouse queries involving views execute properly
3. Monitor query performance to ensure parallel view processing is working as expected

### Why make this change?

Enabling parallel view processing allows ClickHouse to process views more efficiently by executing parts of view queries in parallel. This can significantly improve performance for complex queries that involve views, especially on systems with multiple CPU cores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated database connection settings to include an additional ClickHouse configuration for improved processing. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->