### PR TITLE
fixed indexed log params decoding

### DIFF
--- a/internal/common/log.go
+++ b/internal/common/log.go
@@ -188,9 +188,7 @@ func decodeIndexedArgument(argType abi.Type, topic string) (interface{}, error) 
 		return new(big.Int).SetBytes(topicBytes), nil
 	case abi.BoolTy:
 		return topicBytes[0] != 0, nil
-	case abi.StringTy:
-		return string(topicBytes), nil
-	case abi.BytesTy, abi.FixedBytesTy:
+	case abi.BytesTy, abi.FixedBytesTy, abi.StringTy:
 		return "0x" + gethCommon.Bytes2Hex(topicBytes), nil
 	case abi.HashTy:
 		if len(topicBytes) != 32 {
@@ -201,10 +199,8 @@ func decodeIndexedArgument(argType abi.Type, topic string) (interface{}, error) 
 		bi := new(big.Int).SetBytes(topicBytes)
 		bf := new(big.Float).SetInt(bi)
 		return bf, nil
-	case abi.SliceTy, abi.ArrayTy, abi.TupleTy:
-		return nil, fmt.Errorf("type %s is not supported for indexed parameters", argType.String())
 	default:
-		return nil, fmt.Errorf("unsupported indexed type: %s", argType.String())
+		return topic, nil
 	}
 }
 


### PR DESCRIPTION
### TL;DR

Improved handling of indexed event parameters in Ethereum logs.

Dynamic size types will be keccak256 hashes into the topic value, so we cannot decode them

### What changed?

- Consolidated the handling of `StringTy`, `BytesTy`, and `FixedBytesTy` types to return hex-encoded strings
- Replaced specific error handling for unsupported types (`SliceTy`, `ArrayTy`, `TupleTy`) with a default case that returns the raw topic string
- Simplified the error handling logic for indexed parameters

### How to test?

1. Test decoding logs with indexed string parameters
2. Verify that previously unsupported types now return the raw topic value instead of an error
3. Ensure that hex encoding for byte types and strings works correctly

### Why make this change?

This change improves the robustness of log decoding by:
1. Providing consistent handling for string and byte types
2. Allowing the application to continue processing even with complex indexed types instead of failing
3. Simplifying the code while maintaining functionality for common types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in how string and byte types are decoded from indexed log topics, now returning them as hex-encoded strings prefixed with "0x".
  - Enhanced error handling for unsupported or unknown indexed argument types by returning the raw topic string instead of an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->