### PR TITLE
setup workmode determination and update

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -144,3 +144,11 @@ var (
 		Buckets: prometheus.DefBuckets,
 	})
 )
+
+// Work Mode Metrics
+var (
+	CurrentWorkMode = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "current_work_mode",
+		Help: "The current work mode (0 = backfill, 1 = live)",
+	})
+)

--- a/internal/orchestrator/committer_test.go
+++ b/internal/orchestrator/committer_test.go
@@ -372,6 +372,7 @@ func TestStartCommitter(t *testing.T) {
 
 	committer := NewCommitter(mockRPC, mockStorage)
 	committer.triggerIntervalMs = 100 // Set a short interval for testing
+	committer.workMode = WorkModeBackfill
 
 	chainID := big.NewInt(1)
 	mockRPC.EXPECT().GetChainID().Return(chainID)
@@ -405,6 +406,7 @@ func TestCommitterRespectsSIGTERM(t *testing.T) {
 
 	committer := NewCommitter(mockRPC, mockStorage)
 	committer.triggerIntervalMs = 100 // Short interval for testing
+	committer.workMode = WorkModeBackfill
 
 	chainID := big.NewInt(1)
 	mockRPC.EXPECT().GetChainID().Return(chainID)

--- a/internal/orchestrator/work_mode_monitor.go
+++ b/internal/orchestrator/work_mode_monitor.go
@@ -1,0 +1,153 @@
+package orchestrator
+
+import (
+	"context"
+	"math/big"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/thirdweb-dev/indexer/internal/metrics"
+	"github.com/thirdweb-dev/indexer/internal/rpc"
+	"github.com/thirdweb-dev/indexer/internal/storage"
+)
+
+type WorkMode string
+
+const (
+	WORK_MODE_CHECK_INTERVAL              = 10 * time.Minute
+	WORK_MODE_BACKFILL_THRESHOLD          = 500
+	WorkModeLive                 WorkMode = "live"
+	WorkModeBackfill             WorkMode = "backfill"
+)
+
+type WorkModeMonitor struct {
+	rpc              rpc.IRPCClient
+	storage          storage.IStorage
+	workModeChannels map[chan WorkMode]struct{}
+	channelsMutex    sync.RWMutex
+	currentMode      WorkMode
+}
+
+func NewWorkModeMonitor(rpc rpc.IRPCClient, storage storage.IStorage) *WorkModeMonitor {
+	return &WorkModeMonitor{
+		rpc:              rpc,
+		storage:          storage,
+		workModeChannels: make(map[chan WorkMode]struct{}),
+		currentMode:      "",
+	}
+}
+
+// RegisterChannel adds a new channel to receive work mode updates
+func (m *WorkModeMonitor) RegisterChannel(ch chan WorkMode) {
+	m.channelsMutex.Lock()
+	defer m.channelsMutex.Unlock()
+
+	m.workModeChannels[ch] = struct{}{}
+	// Send current mode to the new channel only if it's not empty
+	if m.currentMode != "" {
+		select {
+		case ch <- m.currentMode:
+			log.Debug().Msg("Initial work mode sent to new channel")
+		default:
+			log.Warn().Msg("Failed to send initial work mode to new channel - channel full")
+		}
+	}
+}
+
+// UnregisterChannel removes a channel from receiving work mode updates
+func (m *WorkModeMonitor) UnregisterChannel(ch chan WorkMode) {
+	m.channelsMutex.Lock()
+	defer m.channelsMutex.Unlock()
+
+	delete(m.workModeChannels, ch)
+}
+
+func (m *WorkModeMonitor) updateWorkModeMetric(mode WorkMode) {
+	var value float64
+	if mode == WorkModeLive {
+		value = 1
+	}
+	metrics.CurrentWorkMode.Set(value)
+}
+
+func (m *WorkModeMonitor) Start(ctx context.Context) {
+	// Perform immediate check
+	newMode, err := m.determineWorkMode(ctx)
+	if err != nil {
+		log.Error().Err(err).Msg("Error checking work mode during startup")
+	} else if newMode != m.currentMode {
+		log.Info().Msgf("Work mode changing from %s to %s during startup", m.currentMode, newMode)
+		m.currentMode = newMode
+		m.updateWorkModeMetric(newMode)
+		m.broadcastWorkMode(newMode)
+	}
+
+	ticker := time.NewTicker(WORK_MODE_CHECK_INTERVAL)
+	defer ticker.Stop()
+
+	log.Info().Msgf("Work mode monitor started with initial mode: %s", m.currentMode)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Info().Msg("Work mode monitor shutting down")
+			return
+		case <-ticker.C:
+			newMode, err := m.determineWorkMode(ctx)
+			if err != nil {
+				log.Error().Err(err).Msg("Error checking work mode")
+				continue
+			}
+
+			if newMode != m.currentMode {
+				log.Info().Msgf("Work mode changing from %s to %s", m.currentMode, newMode)
+				m.currentMode = newMode
+				m.updateWorkModeMetric(newMode)
+				m.broadcastWorkMode(newMode)
+			}
+		}
+	}
+}
+
+func (m *WorkModeMonitor) broadcastWorkMode(mode WorkMode) {
+	m.channelsMutex.RLock()
+	defer m.channelsMutex.RUnlock()
+
+	for ch := range m.workModeChannels {
+		select {
+		case ch <- mode:
+			log.Debug().Msg("Work mode change notification sent")
+		default:
+			if r := recover(); r != nil {
+				log.Warn().Msg("Work mode notification dropped - channel closed")
+				delete(m.workModeChannels, ch)
+			}
+		}
+	}
+}
+
+func (m *WorkModeMonitor) determineWorkMode(ctx context.Context) (WorkMode, error) {
+	lastCommittedBlock, err := m.storage.MainStorage.GetMaxBlockNumber(m.rpc.GetChainID())
+	if err != nil {
+		return "", err
+	}
+
+	if lastCommittedBlock.Sign() == 0 {
+		log.Debug().Msg("No blocks committed yet, using backfill mode")
+		return WorkModeBackfill, nil
+	}
+
+	latestBlock, err := m.rpc.GetLatestBlockNumber(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	blockDiff := new(big.Int).Sub(latestBlock, lastCommittedBlock)
+	log.Debug().Msgf("Committer is %d blocks behind the chain", blockDiff.Int64())
+	if blockDiff.Cmp(big.NewInt(WORK_MODE_BACKFILL_THRESHOLD)) < 0 {
+		return WorkModeLive, nil
+	}
+
+	return WorkModeBackfill, nil
+}


### PR DESCRIPTION
### TL;DR

Added a work mode monitor to dynamically switch between backfill and live processing modes.

### What changed?

- Created a new `WorkModeMonitor` component that determines whether the system should operate in "backfill" or "live" mode based on how far behind the indexer is from the chain head
- Added communication channels between the monitor and other components (Poller and Committer)
- Modified the Poller to shut down when switching to live mode
- Added Prometheus metrics to track the current work mode
- Implemented functional options pattern for Poller and Committer initialization

### How to test?

1. Run the indexer and observe the logs for work mode changes
2. Check the Prometheus metrics for `current_work_mode` (0 = backfill, 1 = live)
3. Verify that the Poller shuts down when the system transitions to live mode
4. Test with different block heights to ensure the system correctly switches between modes based on the configured threshold (500 blocks)

### Why make this change?

This change improves resource utilization by dynamically adapting the system's behavior based on its current state:
- In backfill mode, the system uses parallel pollers to catch up with historical data
- In live mode, the system stops the resource-intensive polling process since it's already caught up with the chain
- This approach prevents unnecessary resource consumption once the indexer is up-to-date with the blockchain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced automatic detection and switching between "live" and "backfill" operational modes based on blockchain synchronization status.
  - Added real-time metrics to display the current operational mode.
  - Components now dynamically respond to changes in work mode, improving system adaptability and monitoring.

- **Bug Fixes**
  - Improved logging and shutdown handling during mode transitions for better reliability and transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->