### PR TITLE
poll new blocks in the committer when in live mode

### DIFF
--- a/internal/orchestrator/committer_test.go
+++ b/internal/orchestrator/committer_test.go
@@ -25,6 +25,7 @@ func TestNewCommitter(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 
 	assert.NotNil(t, committer)
 	assert.Equal(t, DEFAULT_COMMITTER_TRIGGER_INTERVAL, committer.triggerIntervalMs)
@@ -40,12 +41,13 @@ func TestGetBlockNumbersToCommit(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(100), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -63,12 +65,13 @@ func TestGetBlockNumbersToCommitWithoutConfiguredAndNotStored(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(0), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -89,12 +92,13 @@ func TestGetBlockNumbersToCommitWithConfiguredAndNotStored(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(0), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -115,12 +119,13 @@ func TestGetBlockNumbersToCommitWithConfiguredAndStored(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(2000), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -138,12 +143,13 @@ func TestGetBlockNumbersToCommitWithoutConfiguredAndStored(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(2000), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -164,12 +170,13 @@ func TestGetBlockNumbersToCommitWithStoredHigherThanInMemory(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(2000), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -190,12 +197,13 @@ func TestGetBlockNumbersToCommitWithStoredLowerThanInMemory(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(99), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(blockNumbers))
@@ -214,12 +222,13 @@ func TestGetBlockNumbersToCommitWithStoredEqualThanInMemory(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(2000), nil)
 
-	blockNumbers, err := committer.getBlockNumbersToCommit()
+	blockNumbers, err := committer.getBlockNumbersToCommit(context.Background())
 
 	assert.NoError(t, err)
 	assert.Equal(t, committer.blocksPerCommit, len(blockNumbers))
@@ -239,6 +248,7 @@ func TestGetSequentialBlockDataToCommit(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
@@ -273,6 +283,7 @@ func TestGetSequentialBlockDataToCommitWithDuplicateBlocks(t *testing.T) {
 		StagingStorage: mockStagingStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 	chainID := big.NewInt(1)
 
 	mockRPC.EXPECT().GetChainID().Return(chainID)
@@ -311,6 +322,7 @@ func TestCommit(t *testing.T) {
 		OrchestratorStorage: mockOrchestratorStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 
 	blockData := []common.BlockData{
 		{Block: common.Block{Number: big.NewInt(101)}},
@@ -336,6 +348,7 @@ func TestHandleGap(t *testing.T) {
 		OrchestratorStorage: mockOrchestratorStorage,
 	}
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 
 	expectedStartBlockNumber := big.NewInt(100)
 	actualFirstBlock := common.Block{Number: big.NewInt(105)}
@@ -459,6 +472,7 @@ func TestHandleMissingStagingData(t *testing.T) {
 	}
 
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 
 	chainID := big.NewInt(1)
 	mockRPC.EXPECT().GetChainID().Return(chainID)
@@ -505,6 +519,7 @@ func TestHandleMissingStagingDataIsPolledWithCorrectBatchSize(t *testing.T) {
 	}
 
 	committer := NewCommitter(mockRPC, mockStorage)
+	committer.workMode = WorkModeBackfill
 
 	chainID := big.NewInt(1)
 	mockRPC.EXPECT().GetChainID().Return(chainID)


### PR DESCRIPTION
### TL;DR

Added support for real-time block committing in addition to backfill mode.

### What changed?

- Added a new `getBlockToCommitUntil` function that determines the end block for committing based on work mode
- In real-time mode, the committer now checks the latest block from RPC and uses that as the upper bound if it's less than the calculated end block
- Created a `fetchBlockDataToCommit` function that handles different data retrieval strategies based on work mode:
  - In backfill mode: retrieves data from staging storage
  - In real-time mode: uses a `BoundlessPoller` to fetch data directly without saving to staging first
- Updated the `getBlockNumbersToCommit` function to accept a context parameter
- Refactored `getSequentialBlockDataToCommit` to use the new functions

### How to test?

1. Run the application in real-time mode and verify it correctly commits blocks up to the latest block from RPC
2. Run the application in backfill mode and verify it commits blocks in batches of `blocksPerCommit`
3. Verify that when switching between modes, the committer correctly adjusts its behavior

### Why make this change?

This change enables the committer to operate in two distinct modes:
1. Backfill mode: for historical data processing where blocks are first staged then committed
2. Real-time mode: for processing current blocks directly from the RPC without staging

This dual-mode approach improves efficiency by allowing real-time processing to skip the staging step when immediate data is needed, while maintaining the ability to process historical data in batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved block data fetching logic to dynamically adjust commit ranges based on current mode and blockchain state.
- **Bug Fixes**
	- Updated gap handling to skip unnecessary operations in live mode, reducing redundant processing.
- **Tests**
	- Enhanced test coverage to reflect new context-based method signatures and work mode handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->