### PR TITLE
config options for work mode monitor

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -125,6 +125,8 @@ func init() {
 	rootCmd.PersistentFlags().String("publisher-events-topicName", "", "Kafka topic name for events")
 	rootCmd.PersistentFlags().String("publisher-events-addressFilter", "", "Filter events by address")
 	rootCmd.PersistentFlags().String("publisher-events-topic0Filter", "", "Filter events by topic0")
+	rootCmd.PersistentFlags().Int("workMode-checkIntervalMinutes", 10, "How often to check work mode in minutes")
+	rootCmd.PersistentFlags().Int64("workMode-liveModeThreshold", 500, "How many blocks the indexer can be behind before switching to live mode")
 	viper.BindPFlag("rpc.url", rootCmd.PersistentFlags().Lookup("rpc-url"))
 	viper.BindPFlag("rpc.blocks.blocksPerRequest", rootCmd.PersistentFlags().Lookup("rpc-blocks-blocksPerRequest"))
 	viper.BindPFlag("rpc.blocks.batchDelay", rootCmd.PersistentFlags().Lookup("rpc-blocks-batchDelay"))
@@ -214,6 +216,8 @@ func init() {
 	viper.BindPFlag("publisher.events.topicName", rootCmd.PersistentFlags().Lookup("publisher-events-topicName"))
 	viper.BindPFlag("publisher.events.addressFilter", rootCmd.PersistentFlags().Lookup("publisher-events-addressFilter"))
 	viper.BindPFlag("publisher.events.topic0Filter", rootCmd.PersistentFlags().Lookup("publisher-events-topic0Filter"))
+	viper.BindPFlag("workMode.checkIntervalMinutes", rootCmd.PersistentFlags().Lookup("workMode-checkIntervalMinutes"))
+	viper.BindPFlag("workMode.liveModeThreshold", rootCmd.PersistentFlags().Lookup("workMode-liveModeThreshold"))
 	rootCmd.AddCommand(orchestratorCmd)
 	rootCmd.AddCommand(apiCmd)
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -166,6 +166,11 @@ type PublisherConfig struct {
 	Events       EventPublisherConfig       `mapstructure:"events"`
 }
 
+type WorkModeConfig struct {
+	CheckIntervalMinutes int   `mapstructure:"checkIntervalMinutes"`
+	LiveModeThreshold    int64 `mapstructure:"liveModeThreshold"`
+}
+
 type Config struct {
 	RPC              RPCConfig              `mapstructure:"rpc"`
 	Log              LogConfig              `mapstructure:"log"`
@@ -176,6 +181,7 @@ type Config struct {
 	Storage          StorageConfig          `mapstructure:"storage"`
 	API              APIConfig              `mapstructure:"api"`
 	Publisher        PublisherConfig        `mapstructure:"publisher"`
+	WorkMode         WorkModeConfig         `mapstructure:"workMode"`
 }
 
 var Cfg Config


### PR DESCRIPTION
### TL;DR

Added configurable parameters for work mode monitoring to control check interval and live mode threshold.

### What changed?

- Added two new configuration parameters to the root command:
  - `workMode-checkIntervalMinutes`: Controls how often the work mode is checked (default: 10 minutes)
  - `workMode-liveModeThreshold`: Controls how many blocks behind the indexer can be before switching to live mode (default: 500 blocks)
- Created a new `WorkModeConfig` struct in the config file to store these parameters
- Modified the `WorkModeMonitor` to use these configurable values instead of hardcoded constants
- Added proper fallback to default values if the configured values are invalid

### How to test?

1. Run the indexer with custom work mode settings:
   ```
   ./indexer --workMode-checkIntervalMinutes=5 --workMode-liveModeThreshold=1000
   ```
2. Verify in logs that the work mode monitor initializes with the provided values:
   ```
   Work mode monitor initialized with check interval 5 and live mode threshold 1000
   ```
3. Observe that the work mode checks happen at the configured interval and the mode switches based on the configured threshold

### Why make this change?

This change allows operators to fine-tune the work mode monitoring behavior based on their specific needs. Different chains and indexing scenarios may require different thresholds for determining when to switch between live and backfill modes. Making these parameters configurable improves the flexibility of the indexer without requiring code changes.