### PR TITLE
fix page 0 and 1 returning same results

### DIFF
--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -515,8 +515,8 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 	}
 
 	// Add limit clause
-	if qf.Page > 0 && qf.Limit > 0 {
-		offset := (qf.Page - 1) * qf.Limit
+	if qf.Page >= 0 && qf.Limit > 0 {
+		offset := qf.Page * qf.Limit
 		query += fmt.Sprintf(" LIMIT %d OFFSET %d", qf.Limit, offset)
 	} else if qf.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", qf.Limit)
@@ -648,8 +648,8 @@ func (c *ClickHouseConnector) buildQuery(table, columns string, qf QueryFilter) 
 	}
 
 	// Add limit clause
-	if qf.Page > 0 && qf.Limit > 0 {
-		offset := (qf.Page - 1) * qf.Limit
+	if qf.Page >= 0 && qf.Limit > 0 {
+		offset := qf.Page * qf.Limit
 		query += fmt.Sprintf(" LIMIT %d OFFSET %d", qf.Limit, offset)
 	} else if qf.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", qf.Limit)
@@ -1613,8 +1613,8 @@ func (c *ClickHouseConnector) GetTokenTransfers(qf TransfersQueryFilter, fields 
 	}
 
 	// Add limit clause
-	if qf.Page > 0 && qf.Limit > 0 {
-		offset := (qf.Page - 1) * qf.Limit
+	if qf.Page >= 0 && qf.Limit > 0 {
+		offset := qf.Page * qf.Limit
 		query += fmt.Sprintf(" LIMIT %d OFFSET %d", qf.Limit, offset)
 	} else if qf.Limit > 0 {
 		query += fmt.Sprintf(" LIMIT %d", qf.Limit)
@@ -1704,7 +1704,7 @@ func (c *ClickHouseConnector) GetTokenBalances(qf BalancesQueryFilter, fields ..
 	}
 
 	// Add limit clause
-	if qf.Page > 0 && qf.Limit > 0 {
+	if qf.Page >= 0 && qf.Limit > 0 {
 		offset := qf.Page * qf.Limit
 		query += fmt.Sprintf(" LIMIT %d OFFSET %d", qf.Limit, offset)
 	} else if qf.Limit > 0 {


### PR DESCRIPTION
### TL;DR

Fixed pagination logic to use zero-based indexing consistently across all query methods.

### What changed?

- Modified the pagination condition from `qf.Page > 0` to `qf.Page >= 0` in multiple query methods
- Changed the offset calculation from `(qf.Page - 1) * qf.Limit` to `qf.Page * qf.Limit` in methods where it was still using one-based indexing
- This ensures consistent zero-based pagination across all database query functions

### How to test?

1. Test API endpoints that use pagination with `page=0` parameter
2. Verify that the first page of results is returned correctly
3. Test subsequent pages (1, 2, etc.) and confirm proper pagination
4. Check that no results are duplicated or skipped between pages

### Why make this change?

The codebase had inconsistent pagination logic - some methods were using zero-based indexing while others used one-based indexing. This inconsistency could cause confusion for API consumers and potential bugs. This change standardizes all pagination to use zero-based indexing, which is more conventional in programming and aligns with common API practices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pagination behavior for data queries, ensuring more accurate and consistent results when navigating through pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->