### PR TITLE
return data or aggregations as empty array if no results

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -73,9 +73,9 @@ type QueryResponse struct {
 	// @Description Metadata for the query response
 	Meta Meta `json:"meta"`
 	// @Description Query result data
-	Data interface{} `json:"data,omitempty"`
+	Data *interface{} `json:"data,omitempty"`
 	// @Description Aggregation results
-	Aggregations []map[string]interface{} `json:"aggregations,omitempty"`
+	Aggregations *[]map[string]interface{} `json:"aggregations,omitempty"`
 }
 
 func writeError(w http.ResponseWriter, message string, code int) {

--- a/internal/handlers/blocks_handlers.go
+++ b/internal/handlers/blocks_handlers.go
@@ -88,7 +88,7 @@ func handleBlocksRequest(c *gin.Context) {
 			api.InternalErrorHandler(c)
 			return
 		}
-		queryResult.Aggregations = aggregatesResult.Aggregates
+		queryResult.Aggregations = &aggregatesResult.Aggregates
 		queryResult.Meta.TotalItems = len(aggregatesResult.Aggregates)
 	} else {
 		// Retrieve blocks data
@@ -100,7 +100,8 @@ func handleBlocksRequest(c *gin.Context) {
 			return
 		}
 
-		queryResult.Data = serializeBlocks(blocksResult.Data)
+		var data interface{} = serializeBlocks(blocksResult.Data)
+		queryResult.Data = &data
 		queryResult.Meta.TotalItems = len(blocksResult.Data)
 	}
 

--- a/internal/handlers/logs_handlers.go
+++ b/internal/handlers/logs_handlers.go
@@ -168,7 +168,7 @@ func handleLogsRequest(c *gin.Context) {
 			api.InternalErrorHandler(c)
 			return
 		}
-		queryResult.Aggregations = aggregatesResult.Aggregates
+		queryResult.Aggregations = &aggregatesResult.Aggregates
 		queryResult.Meta.TotalItems = len(aggregatesResult.Aggregates)
 	} else {
 		// Retrieve logs data
@@ -180,12 +180,13 @@ func handleLogsRequest(c *gin.Context) {
 			return
 		}
 
+		var data interface{}
 		if decodedLogs := decodeLogsIfNeeded(chainId.String(), logsResult.Data, eventABI, config.Cfg.API.AbiDecodingEnabled && queryParams.Decode); decodedLogs != nil {
-			queryResult.Data = serializeDecodedLogs(decodedLogs)
+			data = serializeDecodedLogs(decodedLogs)
 		} else {
-			queryResult.Data = serializeLogs(logsResult.Data)
+			data = serializeLogs(logsResult.Data)
 		}
-
+		queryResult.Data = &data
 		queryResult.Meta.TotalItems = len(logsResult.Data)
 	}
 

--- a/internal/handlers/search_handlers.go
+++ b/internal/handlers/search_handlers.go
@@ -84,11 +84,12 @@ func Search(c *gin.Context) {
 		return
 	}
 
+	var data interface{} = result
 	sendJSONResponse(c, api.QueryResponse{
 		Meta: api.Meta{
 			ChainId: chainId.Uint64(),
 		},
-		Data: result,
+		Data: &data,
 	})
 }
 

--- a/internal/handlers/token_handlers.go
+++ b/internal/handlers/token_handlers.go
@@ -128,7 +128,8 @@ func GetTokenIdsByType(c *gin.Context) {
 		return
 	}
 
-	queryResult.Data = serializeTokenIds(balancesResult.Data)
+	var data interface{} = serializeTokenIds(balancesResult.Data)
+	queryResult.Data = &data
 	sendJSONResponse(c, queryResult)
 }
 
@@ -224,7 +225,8 @@ func GetTokenBalancesByType(c *gin.Context) {
 		api.InternalErrorHandler(c)
 		return
 	}
-	queryResult.Data = serializeBalances(balancesResult.Data)
+	var data interface{} = serializeBalances(balancesResult.Data)
+	queryResult.Data = &data
 	sendJSONResponse(c, queryResult)
 }
 
@@ -313,7 +315,8 @@ func GetTokenHoldersByType(c *gin.Context) {
 		api.InternalErrorHandler(c)
 		return
 	}
-	queryResult.Data = serializeHolders(balancesResult.Data)
+	var data interface{} = serializeHolders(balancesResult.Data)
+	queryResult.Data = &data
 	sendJSONResponse(c, queryResult)
 }
 

--- a/internal/handlers/transactions_handlers.go
+++ b/internal/handlers/transactions_handlers.go
@@ -187,7 +187,7 @@ func handleTransactionsRequest(c *gin.Context) {
 			api.InternalErrorHandler(c)
 			return
 		}
-		queryResult.Aggregations = aggregatesResult.Aggregates
+		queryResult.Aggregations = &aggregatesResult.Aggregates
 		queryResult.Meta.TotalItems = len(aggregatesResult.Aggregates)
 	} else {
 		// Retrieve logs data
@@ -199,11 +199,13 @@ func handleTransactionsRequest(c *gin.Context) {
 			return
 		}
 
+		var data interface{}
 		if decodedTxs := decodeTransactionsIfNeeded(chainId.String(), transactionsResult.Data, functionABI, config.Cfg.API.AbiDecodingEnabled && queryParams.Decode); decodedTxs != nil {
-			queryResult.Data = serializeDecodedTransactions(decodedTxs)
+			data = serializeDecodedTransactions(decodedTxs)
 		} else {
-			queryResult.Data = serializeTransactions(transactionsResult.Data)
+			data = serializeTransactions(transactionsResult.Data)
 		}
+		queryResult.Data = &data
 		queryResult.Meta.TotalItems = len(transactionsResult.Data)
 	}
 

--- a/internal/handlers/transfer_handlers.go
+++ b/internal/handlers/transfer_handlers.go
@@ -161,7 +161,8 @@ func GetTokenTransfers(c *gin.Context) {
 		return
 	}
 
-	queryResult.Data = serializeTransfers(transfersResult.Data)
+	var data interface{} = serializeTransfers(transfersResult.Data)
+	queryResult.Data = &data
 	sendJSONResponse(c, queryResult)
 }
 

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -535,8 +535,8 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 	columnNames := rows.Columns()
 	columnTypes := rows.ColumnTypes()
 
-	// Collect results
-	var aggregates []map[string]interface{}
+	// Collect results - initialize as empty array to ensure we always return an array
+	aggregates := make([]map[string]interface{}, 0)
 	for rows.Next() {
 		values := make([]interface{}, len(columnNames))
 


### PR DESCRIPTION
### TL;DR

Changed `Data` and `Aggregations` fields in `QueryResponse` to be pointers to ensure consistent JSON serialization with empty arrays.

### What changed?

- Modified the `QueryResponse` struct in `api/api.go` to use pointer types for `Data` and `Aggregations` fields
- Updated all handler implementations to properly assign values to these pointer fields
- Ensured aggregations are initialized as empty arrays rather than nil to maintain consistent JSON output
- Fixed data assignment in various handlers (blocks, logs, transactions, tokens, transfers) to work with the new pointer types

### How to test?

1. Make API requests that return empty result sets and verify JSON responses include empty arrays (`[]`) instead of omitting fields
2. Test endpoints that return aggregations to ensure they properly serialize
3. Verify that all endpoints (blocks, logs, transactions, tokens, transfers, search) continue to return properly formatted data

### Why make this change?

This change ensures consistent JSON serialization behavior. By using pointers for these fields, we can distinguish between nil values (which are omitted from JSON) and empty arrays/objects (which are included as `[]` or `{}`). This makes the API more predictable for clients, as they can always expect these fields to be present in the response when data is available, even if the arrays are empty.