### PR TITLE
track how many rows are inserted into clickhouse

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -152,3 +152,26 @@ var (
 		Help: "The current work mode (0 = backfill, 1 = live)",
 	})
 )
+
+// ClickHouse Insert Row Count Metrics
+var (
+	ClickHouseMainStorageRowsInserted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "clickhouse_main_storage_rows_inserted_total",
+		Help: "The total number of rows inserted into ClickHouse main storage",
+	})
+
+	ClickHouseTransactionsInserted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "clickhouse_transactions_inserted_total",
+		Help: "The total number of transactions inserted into ClickHouse",
+	})
+
+	ClickHouseLogsInserted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "clickhouse_logs_inserted_total",
+		Help: "The total number of logs inserted into ClickHouse",
+	})
+
+	ClickHouseTracesInserted = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "clickhouse_traces_inserted_total",
+		Help: "The total number of traces inserted into ClickHouse",
+	})
+)


### PR DESCRIPTION
### TL;DR

Added Prometheus metrics to track ClickHouse insert operations.

### What changed?

- Added new Prometheus counters in `metrics.go` to track ClickHouse insert operations:
  - `clickhouse_main_storage_rows_inserted_total`
  - `clickhouse_transactions_inserted_total`
  - `clickhouse_logs_inserted_total`
  - `clickhouse_traces_inserted_total`
- Instrumented the ClickHouse connector to increment these counters when data is inserted
- Added metrics tracking in both individual insert methods and batch insert operations

### How to test?

1. Run the application with Prometheus enabled
2. Perform operations that insert data into ClickHouse
3. Check Prometheus metrics endpoint to verify the new counters are incrementing correctly
4. Validate that the metrics accurately reflect the number of rows inserted

### Why make this change?

These metrics provide visibility into the volume of data being inserted into ClickHouse, which is crucial for monitoring system performance and data processing rates. This information helps with capacity planning, identifying bottlenecks, and ensuring the system is operating efficiently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new metrics to track the total number of rows inserted into main storage, transactions, logs, and traces for ClickHouse operations. These metrics provide enhanced visibility into data insertion activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->