### PR TITLE
track number of clickhouse insert operations

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -155,6 +155,11 @@ var (
 
 // ClickHouse Insert Row Count Metrics
 var (
+	ClickHouseMainStorageInsertOperations = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "clickhouse_main_storage_insert_operations",
+		Help: "The total number of insert operations into ClickHouse main storage",
+	})
+
 	ClickHouseMainStorageRowsInserted = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "clickhouse_main_storage_rows_inserted_total",
 		Help: "The total number of rows inserted into ClickHouse main storage",

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -1358,9 +1358,10 @@ func (c *ClickHouseConnector) InsertBlockData(data []common.BlockData) error {
 		metrics.ClickHouseTransactionsInserted.Add(float64(txsCount))
 		metrics.ClickHouseLogsInserted.Add(float64(logsCount))
 		metrics.ClickHouseTracesInserted.Add(float64(tracesCount))
+		metrics.ClickHouseMainStorageRowsInserted.Add(float64(end - i))
+		metrics.ClickHouseMainStorageInsertOperations.Inc()
 	}
 
-	metrics.ClickHouseMainStorageRowsInserted.Add(float64(len(data)))
 	return nil
 }
 


### PR DESCRIPTION
### TL;DR

Added a new ClickHouse insert operations metric and fixed row count tracking.

### What changed?

- Added a new `ClickHouseMainStorageInsertOperations` counter to track the total number of insert operations into ClickHouse main storage
- Modified the `InsertBlockData` method to increment the row count metric within the batch processing loop instead of once at the end
- Now incrementing the new operations counter for each batch of inserts

### How to test?

1. Run the application and verify the new `clickhouse_main_storage_insert_operations` metric is being reported in Prometheus
2. Confirm that `clickhouse_main_storage_rows_inserted_total` now accurately reflects the actual number of rows inserted in batches

### Why make this change?

This change provides better visibility into ClickHouse database operations by tracking not just the total rows inserted but also the number of distinct insert operations. The previous implementation only counted rows at the end of the function, which could be inaccurate if the function processed data in batches. The new approach ensures metrics are incremented correctly for each batch processed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new metric to track the total number of insert operations into ClickHouse main storage.

* **Improvements**
  * Enhanced metrics reporting for ClickHouse inserts by updating row and operation counts per batch, providing more granular monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->