### PR TITLE
set chain ID when initializing simple rpc

### DIFF
--- a/internal/rpc/rpc.go
+++ b/internal/rpc/rpc.go
@@ -107,6 +107,7 @@ func InitializeSimpleRPCWithUrl(url string) (IRPCClient, error) {
 		EthClient: ethClient,
 		url:       url,
 	}
+	rpc.setChainID(context.Background())
 	return IRPCClient(rpc), nil
 }
 


### PR DESCRIPTION
### TL;DR

Added chain ID initialization during RPC client creation.

### What changed?

Modified the `InitializeSimpleRPCWithUrl` function to call `setChainID` with a background context immediately after creating the RPC client. This ensures the chain ID is set during initialization rather than waiting for a later call.

### How to test?

1. Create a new RPC client using `InitializeSimpleRPCWithUrl`
2. Verify that the chain ID is properly set without requiring an explicit call to `setChainID`
3. Test with different network URLs to ensure chain ID is correctly retrieved for each network

### Why make this change?

This change ensures the RPC client has its chain ID properly initialized at creation time, preventing potential issues where code might assume the chain ID is already set. This improves reliability by guaranteeing the chain ID is available as soon as the client is created rather than requiring a separate initialization step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured that the chain ID is set correctly when initializing a new RPC client.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->