### PR TITLE
fix misleading error message

### DIFF
--- a/internal/orchestrator/committer.go
+++ b/internal/orchestrator/committer.go
@@ -113,7 +113,7 @@ func (c *Committer) getBlockNumbersToCommit(ctx context.Context) ([]*big.Int, er
 	}()
 
 	latestCommittedBlockNumber, err := c.storage.MainStorage.GetMaxBlockNumber(c.rpc.GetChainID())
-	log.Info().Msgf("Committer found this max block number in main storage: %s", latestCommittedBlockNumber.String())
+	log.Debug().Msgf("Committer found this max block number in main storage: %s", latestCommittedBlockNumber.String())
 	if err != nil {
 		return nil, err
 	}
@@ -135,8 +135,11 @@ func (c *Committer) getBlockNumbersToCommit(ctx context.Context) ([]*big.Int, er
 	}
 
 	blockCount := new(big.Int).Sub(endBlock, startBlock).Int64() + 1
-	if blockCount < 1 {
+	if blockCount < 0 {
 		return []*big.Int{}, fmt.Errorf("more blocks have been committed than the RPC has available - possible chain reset")
+	}
+	if blockCount == 0 {
+		return []*big.Int{}, nil
 	}
 	blockNumbers := make([]*big.Int, blockCount)
 	for i := int64(0); i < blockCount; i++ {


### PR DESCRIPTION
### TL;DR

Improved committer logic for handling edge cases when determining blocks to commit.

### What changed?

- Changed a log level from `Info` to `Debug` for the message about the max block number found in main storage
- Enhanced the block count validation logic:
  - Split the negative block count check into two separate conditions
  - Added explicit handling for when block count is exactly zero, returning an empty array instead of an error

### How to test?

1. Run the orchestrator with a chain that has no new blocks to commit
2. Verify that the system gracefully handles the zero block case without errors
3. Check logs to confirm the max block number message appears only in debug level

### Why make this change?

The previous implementation treated zero blocks to commit as an error condition, which isn't actually an error state but a valid scenario where the system is already up to date. This change improves the robustness of the committer by properly distinguishing between error conditions (negative block count) and valid no-op conditions (zero block count).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of scenarios with zero blocks to commit, preventing unnecessary errors and ensuring smoother operation.
  * Adjusted logging to reduce noise by reporting certain information at the debug level instead of info.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->