### PR TITLE
remove validate query checks

### DIFF
--- a/internal/common/utils.go
+++ b/internal/common/utils.go
@@ -1,10 +1,7 @@
 package common
 
 import (
-	"fmt"
 	"math/big"
-	"regexp"
-	"strings"
 )
 
 func SliceToChunks[T any](values []T, chunkSize int) [][]T {
@@ -20,68 +17,6 @@ func SliceToChunks[T any](values []T, chunkSize int) [][]T {
 		chunks = append(chunks, values[i:end])
 	}
 	return chunks
-}
-
-var allowedFunctions = map[string]struct{}{
-	"sum":                  {},
-	"count":                {},
-	"countdistinct":        {},
-	"avg":                  {},
-	"max":                  {},
-	"min":                  {},
-	"reinterpretasuint256": {},
-	"reverse":              {},
-	"unhex":                {},
-	"substring":            {},
-	"length":               {},
-	"touint256":            {},
-	"if":                   {},
-	"tostartofmonth":       {},
-	"tostartofday":         {},
-	"tostartofhour":        {},
-	"tostartofminute":      {},
-	"todate":               {},
-	"todatetime":           {},
-	"concat":               {},
-	"in":                   {},
-	"and":                  {},
-	"or":                   {},
-}
-
-var disallowedPatterns = []string{
-	`(?i)\b(INSERT|DELETE|UPDATE|DROP|CREATE|ALTER|TRUNCATE|EXEC|;|--)`,
-}
-
-// ValidateQuery checks the query for disallowed patterns and ensures only allowed functions are used.
-func ValidateQuery(query string) error {
-	// Check for disallowed patterns
-	for _, pattern := range disallowedPatterns {
-		matched, err := regexp.MatchString(pattern, query)
-		if err != nil {
-			return fmt.Errorf("error checking disallowed patterns: %v", err)
-		}
-		if matched {
-			return fmt.Errorf("query contains disallowed keywords or patterns")
-		}
-	}
-
-	// Ensure the query is a SELECT statement
-	trimmedQuery := strings.TrimSpace(strings.ToUpper(query))
-	if !strings.HasPrefix(trimmedQuery, "SELECT") {
-		return fmt.Errorf("only SELECT queries are allowed")
-	}
-
-	// Extract function names and validate them
-	functionPattern := regexp.MustCompile(`(?i)(\b\w+\b)\s*\(`)
-	matches := functionPattern.FindAllStringSubmatch(query, -1)
-	for _, match := range matches {
-		funcName := match[1]
-		if _, ok := allowedFunctions[strings.ToLower(funcName)]; !ok {
-			return fmt.Errorf("function '%s' is not allowed", funcName)
-		}
-	}
-
-	return nil
 }
 
 func ConvertBigNumbersToString(data interface{}) interface{} {

--- a/internal/storage/clickhouse.go
+++ b/internal/storage/clickhouse.go
@@ -473,9 +473,6 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 	// Use the new query building logic
 	query := c.buildQuery(table, selectColumns, qf)
 
-	if err := common.ValidateQuery(query); err != nil {
-		return QueryResult[interface{}]{}, err
-	}
 	// Execute the query
 	rows, err := c.conn.Query(context.Background(), query)
 	if err != nil {
@@ -528,9 +525,6 @@ func (c *ClickHouseConnector) GetAggregations(table string, qf QueryFilter) (Que
 func executeQuery[T any](c *ClickHouseConnector, table, columns string, qf QueryFilter, scanFunc func(driver.Rows) (T, error)) (QueryResult[T], error) {
 	query := c.buildQuery(table, columns, qf)
 
-	if err := common.ValidateQuery(query); err != nil {
-		return QueryResult[T]{}, err
-	}
 	rows, err := c.conn.Query(context.Background(), query)
 	if err != nil {
 		return QueryResult[T]{}, err


### PR DESCRIPTION
### TL;DR

Removed query validation functionality from the codebase. Database users should have the necessary access restrictions instead.

### What changed?

- Removed the `ValidateQuery` function from `internal/common/utils.go`
- Removed related variables (`allowedFunctions` and `disallowedPatterns`)
- Removed unused imports (`fmt`, `regexp`, and `strings`) from `utils.go`
- Removed calls to `ValidateQuery` in `internal/storage/clickhouse.go`

### How to test?

1. Verify that queries still execute correctly in the ClickHouse connector
2. Confirm that previously disallowed queries now execute without validation errors
3. Run the test suite to ensure no regressions in functionality

### Why make this change?

The query validation was likely too restrictive or causing issues with legitimate queries. Removing this validation allows for more flexibility in query construction and execution, potentially enabling more complex queries that were previously blocked by the validation rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed internal query validation checks prior to executing database queries. Queries are now executed directly without additional validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->