### PR TITLE
cleanup blocks on committer start

### DIFF
--- a/internal/orchestrator/committer_test.go
+++ b/internal/orchestrator/committer_test.go
@@ -404,6 +404,9 @@ func TestStartCommitter(t *testing.T) {
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(100), nil)
 
+	// Add expectation for DeleteOlderThan call during cleanup
+	mockStagingStorage.On("DeleteOlderThan", chainID, big.NewInt(100)).Return(nil)
+
 	blockData := []common.BlockData{
 		{Block: common.Block{Number: big.NewInt(101)}},
 		{Block: common.Block{Number: big.NewInt(102)}},
@@ -437,6 +440,9 @@ func TestCommitterRespectsSIGTERM(t *testing.T) {
 	chainID := big.NewInt(1)
 	mockRPC.EXPECT().GetChainID().Return(chainID)
 	mockMainStorage.EXPECT().GetMaxBlockNumber(chainID).Return(big.NewInt(100), nil)
+
+	// Add expectation for DeleteOlderThan call during cleanup
+	mockStagingStorage.On("DeleteOlderThan", chainID, big.NewInt(100)).Return(nil)
 
 	blockData := []common.BlockData{
 		{Block: common.Block{Number: big.NewInt(101)}},

--- a/internal/storage/connector.go
+++ b/internal/storage/connector.go
@@ -83,6 +83,7 @@ type IStagingStorage interface {
 	GetStagingData(qf QueryFilter) (data []common.BlockData, err error)
 	DeleteStagingData(data []common.BlockData) error
 	GetLastStagedBlockNumber(chainId *big.Int, rangeStart *big.Int, rangeEnd *big.Int) (maxBlockNumber *big.Int, err error)
+	DeleteOlderThan(chainId *big.Int, blockNumber *big.Int) error
 }
 
 type IMainStorage interface {

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -388,7 +388,7 @@ func (p *PostgresConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeStar
 }
 
 func (p *PostgresConnector) DeleteOlderThan(chainId *big.Int, blockNumber *big.Int) error {
-	query := `DELETE FROM block_data WHERE chain_id = $1 AND block_number < $2`
+	query := `DELETE FROM block_data WHERE chain_id = $1 AND block_number <= $2`
 	_, err := p.db.Exec(query, chainId.String(), blockNumber.String())
 	return err
 }

--- a/internal/storage/postgres.go
+++ b/internal/storage/postgres.go
@@ -387,6 +387,12 @@ func (p *PostgresConnector) GetLastStagedBlockNumber(chainId *big.Int, rangeStar
 	return blockNumber, nil
 }
 
+func (p *PostgresConnector) DeleteOlderThan(chainId *big.Int, blockNumber *big.Int) error {
+	query := `DELETE FROM block_data WHERE chain_id = $1 AND block_number < $2`
+	_, err := p.db.Exec(query, chainId.String(), blockNumber.String())
+	return err
+}
+
 // Close closes the database connection
 func (p *PostgresConnector) Close() error {
 	return p.db.Close()

--- a/test/mocks/MockIStagingStorage.go
+++ b/test/mocks/MockIStagingStorage.go
@@ -236,6 +236,53 @@ func (_c *MockIStagingStorage_InsertStagingData_Call) RunAndReturn(run func([]co
 	return _c
 }
 
+// DeleteOlderThan provides a mock function with given fields: chainId, blockNumber
+func (_m *MockIStagingStorage) DeleteOlderThan(chainId *big.Int, blockNumber *big.Int) error {
+	ret := _m.Called(chainId, blockNumber)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteOlderThan")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*big.Int, *big.Int) error); ok {
+		r0 = rf(chainId, blockNumber)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockIStagingStorage_DeleteOlderThan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteOlderThan'
+type MockIStagingStorage_DeleteOlderThan_Call struct {
+	*mock.Call
+}
+
+// DeleteOlderThan is a helper method to define mock.On call
+//   - chainId *big.Int
+//   - blockNumber *big.Int
+func (_e *MockIStagingStorage_Expecter) DeleteOlderThan(chainId interface{}, blockNumber interface{}) *MockIStagingStorage_DeleteOlderThan_Call {
+	return &MockIStagingStorage_DeleteOlderThan_Call{Call: _e.mock.On("DeleteOlderThan", chainId, blockNumber)}
+}
+
+func (_c *MockIStagingStorage_DeleteOlderThan_Call) Run(run func(chainId *big.Int, blockNumber *big.Int)) *MockIStagingStorage_DeleteOlderThan_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(*big.Int), args[1].(*big.Int))
+	})
+	return _c
+}
+
+func (_c *MockIStagingStorage_DeleteOlderThan_Call) Return(_a0 error) *MockIStagingStorage_DeleteOlderThan_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockIStagingStorage_DeleteOlderThan_Call) RunAndReturn(run func(*big.Int, *big.Int) error) *MockIStagingStorage_DeleteOlderThan_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockIStagingStorage creates a new instance of MockIStagingStorage. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockIStagingStorage(t interface {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic cleanup of outdated staging data before starting regular operations, ensuring more efficient storage management.
  * Added capability to delete older block data entries from storage for improved data management.

* **Bug Fixes**
  * Improved handling and logging of errors during staging data cleanup processes.

* **Tests**
  * Enhanced test coverage with new mock methods to support validation of staging data cleanup functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->