### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/internal/source/s3.go
+++ b/internal/source/s3.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -255,9 +256,7 @@ func (s *S3Source) GetFullBlocks(ctx context.Context, blockNumbers []*big.Int) [
 			continue
 		}
 
-		for blockNum, result := range fileResults {
-			resultMap[blockNum] = result
-		}
+		maps.Copy(resultMap, fileResults)
 	}
 
 	// Build ordered results


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined internal data merging logic using a standard library utility, reducing boilerplate and improving maintainability with no change to behavior or public interfaces.
  - Minor efficiency and readability improvements in block aggregation paths.
- Chores
  - No user-facing changes; existing functionality continues to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->