### PR TITLE
Remove FINAL from ClickHouse queries

### DIFF
--- a/internal/libs/clickhouse.go
+++ b/internal/libs/clickhouse.go
@@ -415,7 +415,7 @@ func GetTransactionMismatchRangeFromClickHouseV2(chainId uint64, startBlockNumbe
 
 	// Aggregate transaction counts per block from the transactions table.
 	query := fmt.Sprintf(
-		"SELECT block_number, count() AS tx_count FROM %s.transactions FINAL WHERE chain_id = %d AND block_number BETWEEN %d AND %d GROUP BY block_number ORDER BY block_number",
+		"SELECT block_number, count() AS tx_count FROM %s.transactions WHERE chain_id = %d AND block_number BETWEEN %d AND %d GROUP BY block_number ORDER BY block_number",
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
 		startBlockNumber,
@@ -492,7 +492,7 @@ func GetLogsMismatchRangeFromClickHouseV2(chainId uint64, startBlockNumber uint6
 
 	// Aggregate log counts and max log_index per block from the logs table.
 	query := fmt.Sprintf(
-		"SELECT block_number, count() AS log_count, max(log_index) AS max_log_index FROM %s.logs FINAL WHERE chain_id = %d AND block_number BETWEEN %d AND %d GROUP BY block_number ORDER BY block_number",
+		"SELECT block_number, count() AS log_count, max(log_index) AS max_log_index FROM %s.logs WHERE chain_id = %d AND block_number BETWEEN %d AND %d GROUP BY block_number ORDER BY block_number",
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
 		startBlockNumber,
@@ -560,7 +560,7 @@ func getBlocksFromV2(chainId uint64, startBlockNumber uint64, endBlockNumber uin
 	length := endBlockNumber - startBlockNumber + 1
 	blocksRaw := make([]common.Block, length)
 
-	query := fmt.Sprintf("SELECT %s FROM %s.blocks FINAL WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number",
+	query := fmt.Sprintf("SELECT %s FROM %s.blocks WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number",
 		strings.Join(defaultBlockFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
@@ -589,7 +589,7 @@ func getTransactionsFromV2(chainId uint64, startBlockNumber uint64, endBlockNumb
 	length := endBlockNumber - startBlockNumber + 1
 	transactionsRaw := make([][]common.Transaction, length)
 
-	query := fmt.Sprintf("SELECT %s FROM %s.transactions FINAL WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number, transaction_index",
+	query := fmt.Sprintf("SELECT %s FROM %s.transactions WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number, transaction_index",
 		strings.Join(defaultTransactionFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
@@ -618,7 +618,7 @@ func getLogsFromV2(chainId uint64, startBlockNumber uint64, endBlockNumber uint6
 	length := endBlockNumber - startBlockNumber + 1
 	logsRaw := make([][]common.Log, length)
 
-	query := fmt.Sprintf("SELECT %s FROM %s.logs FINAL WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number, log_index",
+	query := fmt.Sprintf("SELECT %s FROM %s.logs WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number, log_index",
 		strings.Join(defaultLogFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
@@ -647,7 +647,7 @@ func getTracesFromV2(chainId uint64, startBlockNumber uint64, endBlockNumber uin
 	length := endBlockNumber - startBlockNumber + 1
 	tracesRaw := make([][]common.Trace, length)
 
-	query := fmt.Sprintf("SELECT %s FROM %s.traces FINAL WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number",
+	query := fmt.Sprintf("SELECT %s FROM %s.traces WHERE chain_id = %d AND block_number BETWEEN %d AND %d order by block_number",
 		strings.Join(defaultTraceFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,

--- a/internal/libs/clickhouse.go
+++ b/internal/libs/clickhouse.go
@@ -269,7 +269,7 @@ func queryBlocksByBlockNumbers(chainId uint64, nums []uint64) ([]common.Block, e
 		return nil, nil
 	}
 	q := fmt.Sprintf(
-		"SELECT %s FROM %s.blocks FINAL WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number",
+		"SELECT %s FROM %s.blocks WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number",
 		strings.Join(defaultBlockFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
@@ -283,7 +283,7 @@ func queryTransactionsByBlockNumbers(chainId uint64, nums []uint64) ([]common.Tr
 		return nil, nil
 	}
 	q := fmt.Sprintf(
-		"SELECT %s FROM %s.transactions FINAL WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number, transaction_index",
+		"SELECT %s FROM %s.transactions WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number, transaction_index",
 		strings.Join(defaultTransactionFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
@@ -297,7 +297,7 @@ func queryLogsByBlockNumbers(chainId uint64, nums []uint64) ([]common.Log, error
 		return nil, nil
 	}
 	q := fmt.Sprintf(
-		"SELECT %s FROM %s.logs FINAL WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number, log_index",
+		"SELECT %s FROM %s.logs WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number, log_index",
 		strings.Join(defaultLogFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,
@@ -311,7 +311,7 @@ func queryTracesByBlockNumbers(chainId uint64, nums []uint64) ([]common.Trace, e
 		return nil, nil
 	}
 	q := fmt.Sprintf(
-		"SELECT %s FROM %s.traces FINAL WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number, transaction_index",
+		"SELECT %s FROM %s.traces WHERE chain_id = %d AND block_number IN (%s) ORDER BY block_number, transaction_index",
 		strings.Join(defaultTraceFields, ", "),
 		config.Cfg.CommitterClickhouseDatabase,
 		chainId,


### PR DESCRIPTION
Remove the FINAL clause from multiple SELECT queries in internal/libs/clickhouse.go. Affected functions: GetTransactionMismatchRangeFromClickHouseV2, GetLogsMismatchRangeFromClickHouseV2, getBlocksFromV2, getTransactionsFromV2, getLogsFromV2, and getTracesFromV2. Queries now read directly from the respective tables (blocks, transactions, logs, traces) without the FINAL modifier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved database query efficiency for block, transaction, log, and trace retrieval and related aggregations. Queries now run with reduced finalization overhead while preserving existing control flow and result behavior, keeping aggregation and mismatch-range calculations unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->