### PR TITLE
reorg lag env

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -91,6 +91,8 @@ type Config struct {
 	RedisDB                          int    `env:"REDIS_DB" envDefault:"0"`
 	ValidationMode                   string `env:"VALIDATION_MODE" envDefault:"minimal"`
 	EnableReorgValidation            bool   `env:"ENABLE_REORG_VALIDATION" envDefault:"true"`
+	// ReorgLagByBlocks keeps reorg validation this many ClickHouse blocks behind the latest committed block.
+	ReorgLagByBlocks uint64 `env:"REORG_LAG_BY_BLOCKS" envDefault:"500"`
 	// ReorgAPIListenAddr is the bind address for the manual reorg publish HTTP server (reorg-api command).
 	ReorgAPIListenAddr string `env:"REORG_API_LISTEN_ADDR" envDefault:":8080"`
 	// ReorgAPIKey, when non-empty, requires requests to send Authorization: Bearer <ReorgAPIKey>.

--- a/internal/committer/reorg.go
+++ b/internal/committer/reorg.go
@@ -62,7 +62,7 @@ func getReorgRange() (int64, int64, error) {
 		return 0, 0, fmt.Errorf("failed to get max block number: %w", err)
 	}
 
-	endBlock = min(endBlock-500, startBlock+100) // lag by some blocks for safety
+	endBlock = min(endBlock-int64(config.Cfg.ReorgLagByBlocks), startBlock+100)
 
 	if startBlock >= endBlock {
 		return 0, 0, fmt.Errorf("start block is greater than end block (%d >= %d)", startBlock, endBlock)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable reorg lag setting via the `REORG_LAG_BY_BLOCKS` environment variable (default: 500 blocks).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->